### PR TITLE
[FEAT] 회원탈퇴 기능 구현

### DIFF
--- a/client-service/src/features/profile/DeleteAccountModal.tsx
+++ b/client-service/src/features/profile/DeleteAccountModal.tsx
@@ -1,0 +1,141 @@
+import { useState } from 'react'
+import { userApi } from '../../services/userApi'
+
+type DeleteAccountModalProps = {
+  isOpen: boolean
+  onClose: () => void
+  onSuccess: () => void
+}
+
+export function DeleteAccountModal({ isOpen, onClose, onSuccess }: DeleteAccountModalProps) {
+  const [password, setPassword] = useState('')
+  const [showPassword, setShowPassword] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  if (!isOpen) return null
+
+  const handleDelete = async () => {
+    if (!password) {
+      setError('비밀번호를 입력해주세요.')
+      return
+    }
+
+    if (!window.confirm('정말로 계정을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.')) {
+      return
+    }
+
+    setIsSubmitting(true)
+    setError(null)
+
+    try {
+      await userApi.deleteAccount(password)
+      onSuccess()
+    } catch (err: unknown) {
+      const apiError = err as { status: number; message: string; msg?: string; data: unknown }
+      
+      if (apiError.status === 400) {
+        // 이미 탈퇴한 회원 or 비밀번호 누락
+        if (apiError.msg === '이미 탈퇴한 회원입니다.' || apiError.message === '이미 탈퇴한 회원입니다.') {
+           setError(apiError.message || apiError.msg || '잘못된 요청입니다.')
+        } else if (apiError.data && typeof apiError.data === 'object') {
+           // 비밀번호 누락: data.password 확인
+           const errorData = apiError.data as { password?: string }
+           if (errorData.password) {
+             setError(errorData.password)
+           } else {
+             setError(apiError.message || '입력값이 올바르지 않습니다.')
+           }
+        } else {
+           setError(apiError.message || '잘못된 요청입니다.')
+        }
+      } else if (apiError.status === 401) {
+        setError(apiError.message || '비밀번호가 일치하지 않습니다.')
+      } else {
+        setError(apiError.message || '계정 삭제에 실패했습니다.')
+      }
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm p-4">
+      <div className="w-full max-w-[346px] bg-[#101828] border border-[#1e2939] rounded-[24px] p-6 relative overflow-hidden flex flex-col items-center">
+        
+        {/* Icon */}
+        <div className="w-14 h-14 rounded-2xl bg-[#FB2C36]/10 flex items-center justify-center mb-6">
+          <svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M11.6667 3.5H16.3333M3.5 7H24.5M21.5833 7V22.1667C21.5833 22.7855 21.3375 23.379 20.8999 23.8166C20.4623 24.2542 19.8688 24.5 19.25 24.5H8.75C8.13116 24.5 7.53767 24.2542 7.10008 23.8166C6.6625 23.379 6.41667 22.7855 6.41667 22.1667V7H21.5833Z" stroke="#FB2C36" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+            <path d="M11.6667 11.6667V18.6667M16.3333 11.6667V18.6667" stroke="#FB2C36" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+        </div>
+
+        {/* Text */}
+        <h3 className="text-white text-[16px] font-medium leading-[24px] tracking-[-0.3px] mb-2 text-center">
+          계정을 삭제하시겠습니까?
+        </h3>
+        <p className="text-[#99a1af] text-[14px] leading-[20px] tracking-[-0.15px] text-center mb-6">
+          모든 데이터가 영구적으로 삭제되며<br/>복구할 수 없습니다.
+        </p>
+
+        {/* Password Input */}
+        <div className="w-full mb-4">
+          <label className="block text-[#d1d5dc] text-[13px] font-medium mb-1.5 ml-1">
+            비밀번호 확인
+          </label>
+          <div className="relative">
+            <input
+              type={showPassword ? "text" : "password"}
+              value={password}
+              onChange={(e) => {
+                setPassword(e.target.value)
+                setError(null)
+              }}
+              placeholder="비밀번호를 입력하세요"
+              disabled={isSubmitting}
+              className={`w-full h-[48px] bg-[#1e2939] border ${error ? 'border-[#FB2C36]' : 'border-[#344054]'} rounded-[12px] pl-4 pr-10 text-white text-[15px] placeholder-[#667085] focus:outline-none focus:border-[#FB2C36] transition-colors`}
+            />
+             <button 
+              type="button"
+              onClick={() => setShowPassword(!showPassword)}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-[#98A2B3] hover:text-white transition-colors"
+            >
+              {showPassword ? (
+                 <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/></svg>
+              ) : (
+                 <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+              )}
+            </button>
+          </div>
+           {error && (
+            <p className="text-[#FB2C36] text-[12px] mt-1.5 ml-1 animate-pulse">
+              {error}
+            </p>
+          )}
+        </div>
+
+        {/* Buttons */}
+        <div className="w-full flex flex-col gap-3">
+          <button
+            onClick={handleDelete}
+            disabled={isSubmitting}
+            className="w-full h-[48px] bg-[#FB2C36] hover:bg-[#D92029] disabled:opacity-50 disabled:cursor-not-allowed rounded-[16px] text-white text-[16px] font-medium tracking-[-0.3px] transition-colors flex items-center justify-center"
+          >
+             {isSubmitting ? (
+               <div className="w-5 h-5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+             ) : '삭제하기'}
+          </button>
+          <button
+            onClick={onClose}
+            disabled={isSubmitting}
+            className="w-full h-[48px] bg-[#1e2939] hover:bg-[#2C3849] rounded-[16px] text-[#d1d5dc] text-[16px] font-medium tracking-[-0.3px] transition-colors"
+          >
+            취소
+          </button>
+        </div>
+
+      </div>
+    </div>
+  )
+}

--- a/client-service/src/features/profile/ProfilePage.tsx
+++ b/client-service/src/features/profile/ProfilePage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../auth'
 import {
@@ -17,6 +18,8 @@ import securitySettingsIcon from '../../assets/profile/security_settings.svg'
 import generalSettingsIcon from '../../assets/profile/general_settings.svg'
 
 
+import { DeleteAccountModal } from './DeleteAccountModal'
+
 type LinkItem = {
   id: string
   title: string
@@ -29,6 +32,7 @@ type LinkItem = {
 export function ProfilePage() {
   const { user, logout } = useAuth()
   const navigate = useNavigate()
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
 
   const handleLogout = () => {
     if (window.confirm('정말 로그아웃하시겠어요?')) {
@@ -37,9 +41,12 @@ export function ProfilePage() {
   }
 
   const handleDeleteAccount = () => {
-    if (window.confirm('정말 계정을 삭제하시겠어요? 이 작업은 되돌릴 수 없습니다.')) {
-      alert('계정 삭제 기능은 아직 구현되지 않았습니다.')
-    }
+    setIsDeleteModalOpen(true)
+  }
+
+  const handleDeleteSuccess = () => {
+    logout()
+    // Additional cleanup if needed
   }
 
   const managementLinks: LinkItem[] = [
@@ -189,6 +196,12 @@ export function ProfilePage() {
 
         <p className="text-center text-[12px] text-slate-600 font-medium py-2">버전 1.0.0</p>
       </div>
+
+      <DeleteAccountModal 
+        isOpen={isDeleteModalOpen}
+        onClose={() => setIsDeleteModalOpen(false)}
+        onSuccess={handleDeleteSuccess}
+      />
     </div>
   )
 }

--- a/client-service/src/services/userApi.ts
+++ b/client-service/src/services/userApi.ts
@@ -19,4 +19,11 @@ export const userApi = {
       body: payload,
     })
   },
+  
+  deleteAccount(password: string) {
+    return apiClient.request<void>('/users', {
+      method: 'DELETE',
+      body: { password },
+    })
+  },
 }

--- a/identity-service/CLAUDE.md
+++ b/identity-service/CLAUDE.md
@@ -1,0 +1,108 @@
+# CLAUDE.md
+
+이 파일은 Claude Code (claude.ai/code)가 이 저장소에서 작업할 때 참고하는 가이드입니다.
+
+## 빌드 및 테스트 명령어
+
+```bash
+# 빌드 (테스트 생략)
+./gradlew clean build -x test
+
+# 전체 테스트 실행
+./gradlew test
+
+# 단일 테스트 클래스 실행
+./gradlew test --tests "com.leedahun.identityservice.domain.auth.service.LoginServiceImplTest"
+
+# 단일 테스트 메서드 실행
+./gradlew test --tests "com.leedahun.identityservice.domain.auth.service.LoginServiceImplTest.login_Success"
+
+# 로컬 애플리케이션 실행 (jwt_key, jasypt_key 환경변수 필요)
+./gradlew bootRun --args='--spring.profiles.active=local'
+
+# JaCoCo 커버리지 리포트 생성
+./gradlew jacocoTestReport
+# 리포트 경로: build/reports/jacoco/test/html/index.html
+```
+
+## 필수 환경변수
+
+- `jwt_key`: JWT 서명용 HMAC512 시크릿
+- `jasypt_key`: application.yml의 `ENC()` 값 복호화 키
+
+## 아키텍처 개요
+
+**Spring Boot 3.5 마이크로서비스** (Java 17)로, key-feed 시스템의 사용자 인증 및 사용자 설정을 담당합니다. 포트 **8081**에서 실행되며 **Eureka**에 등록됩니다.
+
+### 도메인 구조 (DDD)
+
+```
+src/main/java/com/leedahun/identityservice/
+├── config/           # 전역 설정 (Jasypt, JPA 감사, 로깅 AOP, P6spy)
+├── common/           # 공통: BaseTimeEntity, 예외, 응답 래퍼, 유틸리티
+├── domain/
+│   ├── auth/         # 인증: User 엔티티, JWT, 로그인/회원가입, 이메일 인증
+│   ├── bookmark/     # 사용자 북마크 (폴더 구조)
+│   ├── keyword/      # 사용자 키워드 (알림 토글)
+│   └── source/       # RSS/피드 소스 관리 (Source, UserSource)
+└── infra/client/     # OpenFeign 클라이언트 (FeedInternalApiClient → feed-service)
+```
+
+### 주요 패턴
+
+- **Gateway-First 인증**: 보안 필터가 API Gateway의 `X-User-Id`, `X-User-Roles` 헤더를 읽음
+- **Internal API 패턴**: `/internal/**` 엔드포인트는 서비스 간 호출용으로 인증 우회
+- **커서 기반 페이지네이션**: 효율적인 목록 조회를 위해 `CursorPage` 사용
+- **속성 암호화**: 민감한 값은 Jasypt의 `ENC()`로 암호화
+- **Base Entity**: 모든 엔티티는 `BaseTimeEntity`를 상속하여 createdAt/updatedAt 자동 관리
+
+### 보안 흐름
+
+1. 공개 엔드포인트: `/api/auth/**` (회원가입, 로그인, 이메일 인증)
+2. 보호 엔드포인트: `/api/keywords/**`, `/api/sources/**`, `/api/bookmarks/**`
+3. 내부 엔드포인트: `/internal/**`, `/actuator/**` (인증 없음)
+4. JWT: Access 토큰 (10분), Refresh 토큰 (14일, HTTP-only 쿠키)
+
+### 서비스 간 통신
+
+- **FeedInternalApiClient**: `POST /internal/feeds/contents`로 `feed-service` 호출
+- Eureka를 통한 서비스 디스커버리, Spring Cloud LoadBalancer로 로드밸런싱
+
+### 엔티티 관계
+
+```
+User (1:N) Keyword
+User (1:N) UserSource → Source
+User (1:N) BookmarkFolder (1:N) Bookmark
+```
+
+### 애플리케이션 제한
+
+- 사용자당 최대 키워드: 20개
+- 사용자당 최대 북마크 폴더: 7개
+- 이메일 인증: 최대 5회 시도, 15분 잠금, 5분 코드 만료
+
+## Spring 프로필
+
+- `local`: MySQL localhost, 개발용 JWT 만료시간 연장
+- `prod`: 외부 DB, 표준 JWT 만료시간 (기본 활성화)
+
+## 테스트
+
+- 서비스 단위 테스트: Mockito 사용
+- 컨트롤러 통합 테스트: `@SpringBootTest` 사용
+- 보안 테스트: `@WithAnonymousUser` 커스텀 어노테이션
+- 외부 API 모킹: WireMock 사용
+- JaCoCo 제외 대상: `**/common/**`, `**/config/**`, `**/dto/**`, `**/entity/**`, `**/constant/**`
+
+## 코딩 컨벤션
+
+### 중복 코드 제거
+- 중복되는 코드는 별도 메서드로 추출하여 재사용
+- 예: `resolveUser(userId)` 같은 공통 조회 로직은 private 메서드로 분리
+
+### 단일 책임 원칙 (SRP)
+- 클래스와 메서드는 하나의 책임만 가지도록 설계
+- 서비스 계층: 비즈니스 로직만 담당
+- 컨트롤러 계층: 요청/응답 처리만 담당
+- 리포지토리 계층: 데이터 접근만 담당

--- a/identity-service/src/main/java/com/leedahun/identityservice/common/error/handler/GlobalExceptionHandler.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/common/error/handler/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -45,6 +46,12 @@ public class GlobalExceptionHandler {
         });
 
         return ResponseEntity.badRequest().body(new HttpResponse(HttpStatus.BAD_REQUEST, ErrorMessage.INVALID_INPUT_VALUE.getMessage(), errors));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<?> handleHttpMessageNotReadable(HttpMessageNotReadableException e) {
+        return ResponseEntity.badRequest()
+                .body(new HttpResponse(HttpStatus.BAD_REQUEST, ErrorMessage.INVALID_INPUT_VALUE.getMessage(), null));
     }
 
 }

--- a/identity-service/src/main/java/com/leedahun/identityservice/common/message/ErrorMessage.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/common/message/ErrorMessage.java
@@ -50,7 +50,10 @@ public enum ErrorMessage {
 
     // 비밀번호 변경 관련 에러 메시지
     PASSWORD_MISMATCH("새 비밀번호가 일치하지 않습니다."),
-    SAME_PASSWORD("현재 비밀번호와 동일한 비밀번호로 변경할 수 없습니다.");
+    SAME_PASSWORD("현재 비밀번호와 동일한 비밀번호로 변경할 수 없습니다."),
+
+    // 회원탈퇴 관련 에러 메시지
+    USER_ALREADY_WITHDRAWN("이미 탈퇴한 회원입니다.");
 
     private final String message;
 }

--- a/identity-service/src/main/java/com/leedahun/identityservice/common/message/SuccessMessage.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/common/message/SuccessMessage.java
@@ -19,7 +19,9 @@ public enum SuccessMessage {
 
     URL_VALIDATION_SUCCESS("URL 검증 성공"),
 
-    PASSWORD_CHANGE_SUCCESS("비밀번호가 성공적으로 변경되었습니다.");
+    PASSWORD_CHANGE_SUCCESS("비밀번호가 성공적으로 변경되었습니다."),
+
+    WITHDRAW_SUCCESS("회원 탈퇴가 완료되었습니다.");
 
     private final String message;
 }

--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/controller/UserController.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/controller/UserController.java
@@ -3,12 +3,14 @@ package com.leedahun.identityservice.domain.auth.controller;
 import com.leedahun.identityservice.common.message.SuccessMessage;
 import com.leedahun.identityservice.common.response.HttpResponse;
 import com.leedahun.identityservice.domain.auth.dto.PasswordChangeRequestDto;
+import com.leedahun.identityservice.domain.auth.dto.WithdrawRequestDto;
 import com.leedahun.identityservice.domain.auth.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,6 +30,15 @@ public class UserController {
         userService.changePassword(userId, requestDto);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, SuccessMessage.PASSWORD_CHANGE_SUCCESS.getMessage(), null));
+    }
+
+    @DeleteMapping
+    public ResponseEntity<?> withdraw(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody WithdrawRequestDto requestDto) {
+        userService.withdraw(userId, requestDto);
+        return ResponseEntity.ok()
+                .body(new HttpResponse(HttpStatus.OK, SuccessMessage.WITHDRAW_SUCCESS.getMessage(), null));
     }
 
 }

--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/dto/WithdrawRequestDto.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/dto/WithdrawRequestDto.java
@@ -1,0 +1,20 @@
+package com.leedahun.identityservice.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class WithdrawRequestDto {
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+
+}

--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/entity/User.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/entity/User.java
@@ -56,4 +56,8 @@ public class User extends BaseTimeEntity {
         this.password = encodedPassword;
     }
 
+    public void withdraw() {
+        this.isWithdraw = true;
+    }
+
 }

--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/exception/UserAlreadyWithdrawnException.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/exception/UserAlreadyWithdrawnException.java
@@ -1,0 +1,13 @@
+package com.leedahun.identityservice.domain.auth.exception;
+
+import com.leedahun.identityservice.common.error.exception.CustomException;
+import com.leedahun.identityservice.common.message.ErrorMessage;
+import org.springframework.http.HttpStatus;
+
+public class UserAlreadyWithdrawnException extends CustomException {
+
+    public UserAlreadyWithdrawnException() {
+        super(ErrorMessage.USER_ALREADY_WITHDRAWN.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+}

--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/service/UserService.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/service/UserService.java
@@ -1,9 +1,12 @@
 package com.leedahun.identityservice.domain.auth.service;
 
 import com.leedahun.identityservice.domain.auth.dto.PasswordChangeRequestDto;
+import com.leedahun.identityservice.domain.auth.dto.WithdrawRequestDto;
 
 public interface UserService {
 
     void changePassword(Long userId, PasswordChangeRequestDto requestDto);
+
+    void withdraw(Long userId, WithdrawRequestDto requestDto);
 
 }

--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/service/impl/LoginServiceImpl.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/service/impl/LoginServiceImpl.java
@@ -9,6 +9,7 @@ import com.leedahun.identityservice.domain.auth.dto.TokenResult;
 import com.leedahun.identityservice.domain.auth.entity.Role;
 import com.leedahun.identityservice.domain.auth.entity.User;
 import com.leedahun.identityservice.domain.auth.exception.InvalidPasswordException;
+import com.leedahun.identityservice.domain.auth.exception.UserAlreadyWithdrawnException;
 import com.leedahun.identityservice.domain.auth.repository.UserRepository;
 import com.leedahun.identityservice.domain.auth.service.LoginService;
 import com.leedahun.identityservice.domain.auth.util.JwtUtil;
@@ -31,6 +32,10 @@ public class LoginServiceImpl implements LoginService {
     public LoginResult login(LoginRequestDto loginRequestDto) {
         User user = userRepository.findByEmail(loginRequestDto.getEmail())
                 .orElseThrow(() -> new EntityNotFoundException("User", loginRequestDto.getEmail()));
+
+        if (user.isWithdraw()) {
+            throw new UserAlreadyWithdrawnException();
+        }
 
         if (!passwordEncoder.matches(loginRequestDto.getPassword(), user.getPassword())) {
             throw new InvalidPasswordException();

--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/service/impl/UserServiceImpl.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/service/impl/UserServiceImpl.java
@@ -2,12 +2,18 @@ package com.leedahun.identityservice.domain.auth.service.impl;
 
 import com.leedahun.identityservice.common.error.exception.EntityNotFoundException;
 import com.leedahun.identityservice.domain.auth.dto.PasswordChangeRequestDto;
+import com.leedahun.identityservice.domain.auth.dto.WithdrawRequestDto;
 import com.leedahun.identityservice.domain.auth.entity.User;
 import com.leedahun.identityservice.domain.auth.exception.InvalidPasswordException;
 import com.leedahun.identityservice.domain.auth.exception.PasswordMismatchException;
 import com.leedahun.identityservice.domain.auth.exception.SamePasswordException;
+import com.leedahun.identityservice.domain.auth.exception.UserAlreadyWithdrawnException;
 import com.leedahun.identityservice.domain.auth.repository.UserRepository;
 import com.leedahun.identityservice.domain.auth.service.UserService;
+import com.leedahun.identityservice.domain.bookmark.repository.BookmarkFolderRepository;
+import com.leedahun.identityservice.domain.bookmark.repository.BookmarkRepository;
+import com.leedahun.identityservice.domain.keyword.repository.KeywordRepository;
+import com.leedahun.identityservice.domain.source.repository.UserSourceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -20,11 +26,14 @@ public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
     private final BCryptPasswordEncoder passwordEncoder;
+    private final KeywordRepository keywordRepository;
+    private final UserSourceRepository userSourceRepository;
+    private final BookmarkFolderRepository bookmarkFolderRepository;
+    private final BookmarkRepository bookmarkRepository;
 
     @Override
     public void changePassword(Long userId, PasswordChangeRequestDto requestDto) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new EntityNotFoundException("User", String.valueOf(userId)));
+        User user = resolveUser(userId);
 
         if (!passwordEncoder.matches(requestDto.getCurrentPassword(), user.getPassword())) {
             throw new InvalidPasswordException();
@@ -39,6 +48,32 @@ public class UserServiceImpl implements UserService {
         }
 
         user.updatePassword(passwordEncoder.encode(requestDto.getNewPassword()));
+    }
+
+    @Override
+    public void withdraw(Long userId, WithdrawRequestDto requestDto) {
+        User user = resolveUser(userId);
+
+        if (user.isWithdraw()) {
+            throw new UserAlreadyWithdrawnException();
+        }
+
+        if (!passwordEncoder.matches(requestDto.getPassword(), user.getPassword())) {
+            throw new InvalidPasswordException();
+        }
+
+        // 관련 데이터 삭제 (순서 중요: 외래키 제약조건 고려)
+        bookmarkRepository.deleteAllByUserId(userId);
+        bookmarkFolderRepository.deleteAllByUserId(userId);
+        userSourceRepository.deleteAllByUserId(userId);
+        keywordRepository.deleteAllByUserId(userId);
+
+        user.withdraw();
+    }
+
+    private User resolveUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("User", String.valueOf(userId)));
     }
 
 }

--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/bookmark/repository/BookmarkFolderRepository.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/bookmark/repository/BookmarkFolderRepository.java
@@ -3,6 +3,9 @@ package com.leedahun.identityservice.domain.bookmark.repository;
 import com.leedahun.identityservice.domain.bookmark.entity.BookmarkFolder;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BookmarkFolderRepository extends JpaRepository<BookmarkFolder, Long> {
 
@@ -15,6 +18,8 @@ public interface BookmarkFolderRepository extends JpaRepository<BookmarkFolder, 
     // 사용자의 북마크 폴더 개수
     long countByUserId(Long userId);
 
-    void deleteAllByUserId(Long userId);
+    @Modifying
+    @Query("DELETE FROM BookmarkFolder bf WHERE bf.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 
 }

--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/bookmark/repository/BookmarkFolderRepository.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/bookmark/repository/BookmarkFolderRepository.java
@@ -15,4 +15,6 @@ public interface BookmarkFolderRepository extends JpaRepository<BookmarkFolder, 
     // 사용자의 북마크 폴더 개수
     long countByUserId(Long userId);
 
+    void deleteAllByUserId(Long userId);
+
 }

--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/bookmark/repository/BookmarkRepository.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/bookmark/repository/BookmarkRepository.java
@@ -65,6 +65,8 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     @Query("UPDATE Bookmark b SET b.bookmarkFolder = null WHERE b.bookmarkFolder.id = :folderId")
     void updateFolderToNull(@Param("folderId") Long folderId);
 
-    void deleteAllByUserId(Long userId);
+    @Modifying
+    @Query("DELETE FROM Bookmark b WHERE b.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 
 }

--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/bookmark/repository/BookmarkRepository.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/bookmark/repository/BookmarkRepository.java
@@ -65,4 +65,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     @Query("UPDATE Bookmark b SET b.bookmarkFolder = null WHERE b.bookmarkFolder.id = :folderId")
     void updateFolderToNull(@Param("folderId") Long folderId);
 
+    void deleteAllByUserId(Long userId);
+
 }

--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/keyword/repository/KeywordRepository.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/keyword/repository/KeywordRepository.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -26,6 +27,8 @@ public interface KeywordRepository extends JpaRepository<Keyword, Long> {
             "AND us.source.id = :sourceId")
     List<Long> findUserIdsByNamesAndSourceId(@Param("keywords") Set<String> keywords, @Param("sourceId") Long sourceId);
 
-    void deleteAllByUserId(Long userId);
+    @Modifying
+    @Query("DELETE FROM Keyword k WHERE k.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 
 }

--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/keyword/repository/KeywordRepository.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/keyword/repository/KeywordRepository.java
@@ -26,4 +26,6 @@ public interface KeywordRepository extends JpaRepository<Keyword, Long> {
             "AND us.source.id = :sourceId")
     List<Long> findUserIdsByNamesAndSourceId(@Param("keywords") Set<String> keywords, @Param("sourceId") Long sourceId);
 
+    void deleteAllByUserId(Long userId);
+
 }

--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/source/repository/UserSourceRepository.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/source/repository/UserSourceRepository.java
@@ -25,4 +25,6 @@ public interface UserSourceRepository extends JpaRepository<UserSource, Long> {
     """)
     List<UserSource> searchByUserIdAndKeyword(@Param("userId") Long userId, @Param("keyword") String keyword);
 
+    void deleteAllByUserId(Long userId);
+
 }

--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/source/repository/UserSourceRepository.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/source/repository/UserSourceRepository.java
@@ -4,6 +4,7 @@ import com.leedahun.identityservice.domain.source.entity.UserSource;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -25,6 +26,8 @@ public interface UserSourceRepository extends JpaRepository<UserSource, Long> {
     """)
     List<UserSource> searchByUserIdAndKeyword(@Param("userId") Long userId, @Param("keyword") String keyword);
 
-    void deleteAllByUserId(Long userId);
+    @Modifying
+    @Query("DELETE FROM UserSource us WHERE us.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 
 }

--- a/identity-service/src/test/java/com/leedahun/identityservice/domain/auth/service/impl/UserServiceImplTest.java
+++ b/identity-service/src/test/java/com/leedahun/identityservice/domain/auth/service/impl/UserServiceImplTest.java
@@ -9,12 +9,18 @@ import static org.mockito.BDDMockito.verify;
 
 import com.leedahun.identityservice.common.error.exception.EntityNotFoundException;
 import com.leedahun.identityservice.domain.auth.dto.PasswordChangeRequestDto;
+import com.leedahun.identityservice.domain.auth.dto.WithdrawRequestDto;
 import com.leedahun.identityservice.domain.auth.entity.Role;
 import com.leedahun.identityservice.domain.auth.entity.User;
 import com.leedahun.identityservice.domain.auth.exception.InvalidPasswordException;
 import com.leedahun.identityservice.domain.auth.exception.PasswordMismatchException;
 import com.leedahun.identityservice.domain.auth.exception.SamePasswordException;
+import com.leedahun.identityservice.domain.auth.exception.UserAlreadyWithdrawnException;
 import com.leedahun.identityservice.domain.auth.repository.UserRepository;
+import com.leedahun.identityservice.domain.bookmark.repository.BookmarkFolderRepository;
+import com.leedahun.identityservice.domain.bookmark.repository.BookmarkRepository;
+import com.leedahun.identityservice.domain.keyword.repository.KeywordRepository;
+import com.leedahun.identityservice.domain.source.repository.UserSourceRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,6 +38,18 @@ class UserServiceImplTest {
 
     @Mock
     BCryptPasswordEncoder passwordEncoder;
+
+    @Mock
+    KeywordRepository keywordRepository;
+
+    @Mock
+    UserSourceRepository userSourceRepository;
+
+    @Mock
+    BookmarkFolderRepository bookmarkFolderRepository;
+
+    @Mock
+    BookmarkRepository bookmarkRepository;
 
     @InjectMocks
     UserServiceImpl userService;
@@ -175,6 +193,106 @@ class UserServiceImplTest {
                 .isInstanceOf(SamePasswordException.class);
 
         verify(passwordEncoder, never()).encode(any());
+    }
+
+    @Test
+    @DisplayName("회원탈퇴 성공")
+    void withdraw_success() {
+        // given
+        User user = User.builder()
+                .id(USER_ID)
+                .email(EMAIL)
+                .password(ENCODED_PASSWORD)
+                .role(Role.USER)
+                .build();
+
+        WithdrawRequestDto requestDto = WithdrawRequestDto.builder()
+                .password(CURRENT_PASSWORD)
+                .build();
+
+        given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+        given(passwordEncoder.matches(CURRENT_PASSWORD, ENCODED_PASSWORD)).willReturn(true);
+
+        // when
+        userService.withdraw(USER_ID, requestDto);
+
+        // then
+        verify(userRepository).findById(USER_ID);
+        verify(passwordEncoder).matches(CURRENT_PASSWORD, ENCODED_PASSWORD);
+        verify(bookmarkRepository).deleteAllByUserId(USER_ID);
+        verify(bookmarkFolderRepository).deleteAllByUserId(USER_ID);
+        verify(userSourceRepository).deleteAllByUserId(USER_ID);
+        verify(keywordRepository).deleteAllByUserId(USER_ID);
+        assertThat(user.isWithdraw()).isTrue();
+    }
+
+    @Test
+    @DisplayName("회원탈퇴 실패 - 사용자 없음")
+    void withdraw_userNotFound_throws() {
+        // given
+        WithdrawRequestDto requestDto = WithdrawRequestDto.builder()
+                .password(CURRENT_PASSWORD)
+                .build();
+
+        given(userRepository.findById(USER_ID)).willReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() -> userService.withdraw(USER_ID, requestDto))
+                .isInstanceOf(EntityNotFoundException.class);
+
+        verify(passwordEncoder, never()).matches(any(), any());
+        verify(bookmarkRepository, never()).deleteAllByUserId(any());
+    }
+
+    @Test
+    @DisplayName("회원탈퇴 실패 - 이미 탈퇴한 사용자")
+    void withdraw_alreadyWithdrawn_throws() {
+        // given
+        User user = User.builder()
+                .id(USER_ID)
+                .email(EMAIL)
+                .password(ENCODED_PASSWORD)
+                .role(Role.USER)
+                .isWithdraw(true)
+                .build();
+
+        WithdrawRequestDto requestDto = WithdrawRequestDto.builder()
+                .password(CURRENT_PASSWORD)
+                .build();
+
+        given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+
+        // when / then
+        assertThatThrownBy(() -> userService.withdraw(USER_ID, requestDto))
+                .isInstanceOf(UserAlreadyWithdrawnException.class);
+
+        verify(passwordEncoder, never()).matches(any(), any());
+        verify(bookmarkRepository, never()).deleteAllByUserId(any());
+    }
+
+    @Test
+    @DisplayName("회원탈퇴 실패 - 비밀번호 불일치")
+    void withdraw_wrongPassword_throws() {
+        // given
+        User user = User.builder()
+                .id(USER_ID)
+                .email(EMAIL)
+                .password(ENCODED_PASSWORD)
+                .role(Role.USER)
+                .build();
+
+        WithdrawRequestDto requestDto = WithdrawRequestDto.builder()
+                .password("wrongPassword")
+                .build();
+
+        given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("wrongPassword", ENCODED_PASSWORD)).willReturn(false);
+
+        // when / then
+        assertThatThrownBy(() -> userService.withdraw(USER_ID, requestDto))
+                .isInstanceOf(InvalidPasswordException.class);
+
+        verify(bookmarkRepository, never()).deleteAllByUserId(any());
     }
 
 }


### PR DESCRIPTION
- 회원탈퇴 모달 구성
- 회원탈퇴 api 구현
  - 회원탈퇴시 비밀번호 요구
  - 비밀번호가 일치하지 않을 경우 재시도 요구
- 요청본문이 없을 경우 에러 처리 exception handler 추가(기존에 401에러를 반환하던 이슈 해결)