### PR TITLE
[FEAT] 비밀번호 재설정 기능 구현

### DIFF
--- a/client-service/src/features/auth/LoginPage.tsx
+++ b/client-service/src/features/auth/LoginPage.tsx
@@ -111,12 +111,12 @@ export function LoginPage() {
               />
               <span>로그인 유지</span>
             </label>
-            <button
-              type="button"
+            <Link
+              to="/password-reset"
               className="text-[#94A3B8] hover:text-white transition-colors"
             >
               비밀번호 찾기
-            </button>
+            </Link>
           </div>
 
           <button

--- a/client-service/src/features/auth/PasswordResetPage.tsx
+++ b/client-service/src/features/auth/PasswordResetPage.tsx
@@ -4,7 +4,7 @@ import toast from 'react-hot-toast'
 import { ArrowLeftIcon, MailIcon } from './components/AuthIcons'
 import { LoginInput } from './components/LoginInput'
 import { VerificationInput } from './components/VerificationInput'
-// import { authApi } from '../../services/authApi'
+import { authApi } from '../../services/authApi'
 
 export function PasswordResetPage() {
   const [step, setStep] = useState<1 | 2 | 3>(1)
@@ -53,10 +53,12 @@ export function PasswordResetPage() {
     setMessage('')
 
     try {
-      // MOCK: API call bypassed for UI testing
-      // await authApi.sendVerificationCode(email)
-      await new Promise(resolve => setTimeout(resolve, 1000))
+      await authApi.sendVerificationCode(email)
       
+      if (step === 2) {
+        toast.success('인증번호가 재발송되었습니다.')
+      }
+
       setStep(2)
       setTimeLeft(180)
       setIsTimerActive(true)
@@ -65,7 +67,7 @@ export function PasswordResetPage() {
     } catch (error) {
       console.error(error)
       setFeedback('error')
-      setMessage('인증번호 전송에 실패했습니다. 다시 시도해주세요.')
+      setMessage(error instanceof Error ? error.message : '인증번호 전송에 실패했습니다. 다시 시도해주세요.')
     } finally {
       setIsLoading(false)
     }
@@ -80,18 +82,21 @@ export function PasswordResetPage() {
     setMessage('')
 
     try {
-      // MOCK: API call bypassed for UI testing
-      // await authApi.confirmVerificationCode(email, verificationCode)
-      await new Promise(resolve => setTimeout(resolve, 1000))
-
-      setStep(3)
-      setFeedback('idle')
-      setMessage('')
-      setIsTimerActive(false)
+      const response = await authApi.confirmVerificationCode(email, verificationCode)
+      
+      if (response.data.status === 'VERIFIED') {
+        setStep(3)
+        setFeedback('idle')
+        setMessage('')
+        setIsTimerActive(false)
+      } else {
+        setFeedback('error')
+        setMessage(response.message || '인증번호가 일치하지 않습니다.')
+      }
     } catch (error) {
       console.error(error)
       setFeedback('error')
-      setMessage('인증번호가 올바르지 않거나 만료되었습니다.')
+      setMessage(error instanceof Error ? error.message : '인증번호 확인에 실패했습니다.')
     } finally {
       setIsLoading(false)
     }
@@ -106,16 +111,35 @@ export function PasswordResetPage() {
     setMessage('')
 
     try {
-      // MOCK: API call bypassed for UI testing
-      // await authApi.resetPassword({ email, code: verificationCode, password })
-      await new Promise(resolve => setTimeout(resolve, 1000))
+      await authApi.resetPassword({ 
+        email, 
+        newPassword: password, 
+        confirmPassword 
+      })
 
       toast.success('비밀번호가 성공적으로 변경되었습니다.')
       navigate('/login')
     } catch (error) {
       console.error(error)
       setFeedback('error')
-      setMessage('비밀번호 변경에 실패했습니다. 다시 시도해주세요.')
+      
+      let errorMsg = '비밀번호 변경에 실패했습니다. 다시 시도해주세요.'
+      const err = error as { response?: { status: number; data?: { message?: string } } }
+
+      if (err?.response?.status === 400) {
+        const message = err.response.data?.message || ''
+        if (message.includes('동일한 비밀번호')) {
+          errorMsg = '현재 비밀번호와 다른 새 비밀번호를 입력해주세요.'
+        } else if (message.includes('일치하지 않습니다')) {
+          errorMsg = '비밀번호가 일치하지 않습니다.'
+        } else if (message) {
+          errorMsg = message
+        }
+      } else if (error instanceof Error) {
+        errorMsg = error.message
+      }
+
+      setMessage(errorMsg)
     } finally {
       setIsLoading(false)
     }

--- a/client-service/src/features/auth/PasswordResetPage.tsx
+++ b/client-service/src/features/auth/PasswordResetPage.tsx
@@ -1,0 +1,335 @@
+import { useState, useMemo, type FormEvent, useEffect } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import toast from 'react-hot-toast'
+import { ArrowLeftIcon, MailIcon } from './components/AuthIcons'
+import { LoginInput } from './components/LoginInput'
+import { VerificationInput } from './components/VerificationInput'
+// import { authApi } from '../../services/authApi'
+
+export function PasswordResetPage() {
+  const [step, setStep] = useState<1 | 2 | 3>(1)
+  const [email, setEmail] = useState('')
+  const [verificationCode, setVerificationCode] = useState('')
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [feedback, setFeedback] = useState<'idle' | 'success' | 'error'>('idle')
+  const [message, setMessage] = useState('')
+  
+  // Timer state
+  const [timeLeft, setTimeLeft] = useState(180) // 3 minutes
+  const [isTimerActive, setIsTimerActive] = useState(false)
+  const navigate = useNavigate()
+
+  const isEmailValid = useMemo(() => /\S+@\S+\.\S+/.test(email), [email])
+  const isPasswordValid = useMemo(() => password.length >= 8, [password])
+  const isPasswordMatch = useMemo(() => password === confirmPassword, [password, confirmPassword])
+
+  // Timer logic
+  useEffect(() => {
+    let interval: ReturnType<typeof setInterval>
+    if (isTimerActive && timeLeft > 0) {
+      interval = setInterval(() => {
+        setTimeLeft((prev) => prev - 1)
+      }, 1000)
+    } else if (timeLeft === 0) {
+      setIsTimerActive(false)
+    }
+    return () => clearInterval(interval)
+  }, [isTimerActive, timeLeft])
+
+  const formatTime = (seconds: number) => {
+    const m = Math.floor(seconds / 60)
+    const s = seconds % 60
+    return `${m}:${s.toString().padStart(2, '0')}`
+  }
+
+  const handleSendCode = async (e?: FormEvent) => {
+    e?.preventDefault()
+    if (!isEmailValid) return
+
+    setIsLoading(true)
+    setFeedback('idle')
+    setMessage('')
+
+    try {
+      // MOCK: API call bypassed for UI testing
+      // await authApi.sendVerificationCode(email)
+      await new Promise(resolve => setTimeout(resolve, 1000))
+      
+      setStep(2)
+      setTimeLeft(180)
+      setIsTimerActive(true)
+      setFeedback('success')
+      setMessage('')
+    } catch (error) {
+      console.error(error)
+      setFeedback('error')
+      setMessage('인증번호 전송에 실패했습니다. 다시 시도해주세요.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleVerifyCode = async (e: FormEvent) => {
+    e.preventDefault()
+    if (verificationCode.length !== 6) return
+
+    setIsLoading(true)
+    setFeedback('idle')
+    setMessage('')
+
+    try {
+      // MOCK: API call bypassed for UI testing
+      // await authApi.confirmVerificationCode(email, verificationCode)
+      await new Promise(resolve => setTimeout(resolve, 1000))
+
+      setStep(3)
+      setFeedback('idle')
+      setMessage('')
+      setIsTimerActive(false)
+    } catch (error) {
+      console.error(error)
+      setFeedback('error')
+      setMessage('인증번호가 올바르지 않거나 만료되었습니다.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleResetPassword = async (e: FormEvent) => {
+    e.preventDefault()
+    if (!isPasswordValid || !isPasswordMatch) return
+
+    setIsLoading(true)
+    setFeedback('idle')
+    setMessage('')
+
+    try {
+      // MOCK: API call bypassed for UI testing
+      // await authApi.resetPassword({ email, code: verificationCode, password })
+      await new Promise(resolve => setTimeout(resolve, 1000))
+
+      toast.success('비밀번호가 성공적으로 변경되었습니다.')
+      navigate('/login')
+    } catch (error) {
+      console.error(error)
+      setFeedback('error')
+      setMessage('비밀번호 변경에 실패했습니다. 다시 시도해주세요.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleBack = () => {
+    if (step === 2) {
+      setStep(1)
+      setFeedback('idle')
+      setMessage('')
+      setVerificationCode('')
+      setIsTimerActive(false)
+    } else if (step === 3) {
+       setStep(2)
+       setFeedback('idle')
+       setMessage('')
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-black flex justify-center items-center relative overflow-hidden font-['Pretendard','Noto_Sans_KR',system-ui,sans-serif] py-10">
+      {/* Background Decor */}
+      <div className="absolute top-[-100px] left-[-100px] w-[600px] h-[600px] bg-[rgba(173,70,255,0.1)] rounded-full blur-[120px] pointer-events-none" />
+      <div className="absolute bottom-[-100px] right-[-100px] w-[600px] h-[600px] bg-[rgba(43,127,255,0.1)] rounded-full blur-[120px] pointer-events-none" />
+
+      <div className="w-full max-w-[393px] px-6 relative z-10 flex flex-col gap-10">
+        
+        {/* Header */}
+        <div className="flex flex-col gap-6">
+          {step === 1 ? (
+            <Link 
+              to="/login" 
+              className="self-start inline-flex items-center gap-1.5 text-[#94A3B8] hover:text-white transition-colors text-[16px] font-normal no-underline"
+            >
+              <ArrowLeftIcon />
+              <span>돌아가기</span>
+            </Link>
+          ) : (
+            <button 
+              onClick={handleBack}
+              className="self-start inline-flex items-center gap-1.5 text-[#94A3B8] hover:text-white transition-colors text-[16px] font-normal cursor-pointer bg-transparent border-none p-0"
+            >
+              <ArrowLeftIcon />
+              <span>돌아가기</span>
+            </button>
+          )}
+
+          <div className="flex flex-col gap-2">
+             {/* Step Indicator */}
+             <div className="flex items-center gap-2 mb-2">
+                <div className={`w-2 h-2 rounded-full transition-all duration-300 ${step === 1 ? 'w-8 bg-[#2B7FFF]' : 'bg-[#2B7FFF]'}`}></div>
+                <div className={`w-2 h-2 rounded-full transition-all duration-300 ${step === 2 ? 'w-8 bg-[#2B7FFF]' : (step > 2 ? 'bg-[#2B7FFF]' : 'bg-[#334155]')}`}></div>
+                <div className={`w-2 h-2 rounded-full transition-all duration-300 ${step === 3 ? 'w-8 bg-[#2B7FFF]' : 'bg-[#334155]'}`}></div>
+             </div>
+            
+            {step === 1 && (
+              <>
+                <h1 className="text-[28px] font-bold text-white tracking-[-0.02em] leading-tight">
+                  비밀번호를<br/>잊으셨나요?
+                </h1>
+                <p className="text-[15px] text-[#94A3B8] tracking-[-0.01em]">
+                  가입하신 이메일을 입력하시면<br/>
+                  비밀번호 재설정 인증번호를 보내드려요.
+                </p>
+              </>
+            )}
+
+            {step === 2 && (
+              <>
+                <h1 className="text-[28px] font-bold text-white tracking-[-0.02em] leading-tight">
+                  인증번호를<br/>발송했어요
+                </h1>
+                <p className="text-[15px] text-[#94A3B8] tracking-[-0.01em]">
+                  <span className="text-white font-medium">{email}</span>으로<br/>
+                  발송된 인증번호 6자리를 입력해주세요.
+                   {isTimerActive && (
+                    <span className="text-[#2B7FFF] font-medium ml-2">
+                       {formatTime(timeLeft)}
+                    </span>
+                  )}
+                </p>
+              </>
+            )}
+
+            {step === 3 && (
+               <>
+                <h1 className="text-[28px] font-bold text-white tracking-[-0.02em] leading-tight">
+                  비밀번호를<br/>재설정해주세요
+                </h1>
+                <p className="text-[15px] text-[#94A3B8] tracking-[-0.01em]">
+                  새로운 비밀번호를 입력해주세요.
+                </p>
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* Form Steps */}
+        {step === 1 && (
+          <form className="flex flex-col gap-8" onSubmit={handleSendCode}>
+            <label className="flex flex-col gap-2">
+              <span className="text-[14px] font-semibold text-white ml-1">이메일</span>
+              <LoginInput
+                icon={<MailIcon />}
+                type="email"
+                placeholder="example@email.com"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                disabled={isLoading}
+                required
+              />
+            </label>
+
+            {feedback !== 'idle' && (
+              <p className={`text-center text-[14px] ${feedback === 'error' ? 'text-red-400' : 'text-emerald-400'}`}>
+                {message}
+              </p>
+            )}
+
+            <button
+              className="w-full h-[56px] rounded-[16px] text-white text-[16px] font-bold tracking-tight transition-transform active:scale-[0.98] cursor-pointer border-none shadow-[0_4px_14px_0_rgba(43,127,255,0.4)] disabled:opacity-50 disabled:cursor-not-allowed"
+              type="submit"
+              disabled={!isEmailValid || isLoading}
+              style={{ background: 'linear-gradient(90deg, #2B7FFF 0%, #9810FA 100%)' }}
+            >
+              {isLoading ? '전송 중...' : '인증번호 받기'}
+            </button>
+          </form>
+        )}
+
+        {step === 2 && (
+          <form className="flex flex-col gap-8" onSubmit={handleVerifyCode}>
+             <label className="flex flex-col gap-3">
+              <span className="text-[14px] font-semibold text-white ml-1">인증번호</span>
+              <VerificationInput
+                value={verificationCode}
+                onChange={(val) => setVerificationCode(val)}
+                disabled={isLoading}
+              />
+            </label>
+
+            <button
+              type="button"
+              onClick={() => handleSendCode()}
+              disabled={isLoading || isTimerActive}
+              className="text-[#94A3B8] text-[14px] underline underline-offset-4 hover:text-white transition-colors bg-transparent border-none cursor-pointer self-center"
+            >
+              인증번호 재발송
+            </button>
+
+            {feedback !== 'idle' && (
+              <p className={`text-center text-[14px] ${feedback === 'error' ? 'text-red-400' : 'text-emerald-400'}`}>
+                {message}
+              </p>
+            )}
+
+            <button
+              className="w-full h-[56px] rounded-[16px] text-white text-[16px] font-bold tracking-tight transition-transform active:scale-[0.98] cursor-pointer border-none shadow-[0_4px_14px_0_rgba(43,127,255,0.4)] disabled:opacity-50 disabled:cursor-not-allowed"
+              type="submit"
+              disabled={verificationCode.length !== 6 || isLoading}
+              style={{ background: 'linear-gradient(90deg, #2B7FFF 0%, #9810FA 100%)' }}
+            >
+              {isLoading ? '확인 중...' : '인증하기'}
+            </button>
+          </form>
+        )}
+
+        {step === 3 && (
+          <form className="flex flex-col gap-8" onSubmit={handleResetPassword}>
+             <label className="flex flex-col gap-2">
+              <span className="text-[14px] font-semibold text-white ml-1">새 비밀번호</span>
+              <LoginInput
+                type="password"
+                placeholder="영문, 숫자, 특수문자 포함 8자 이상"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                disabled={isLoading}
+                required
+              />
+            </label>
+
+             <label className="flex flex-col gap-2">
+              <span className="text-[14px] font-semibold text-white ml-1">비밀번호 확인</span>
+              <LoginInput
+                type="password"
+                placeholder="비밀번호를 다시 입력해주세요"
+                value={confirmPassword}
+                onChange={(event) => setConfirmPassword(event.target.value)}
+                disabled={isLoading}
+                required
+              />
+               {!isPasswordMatch && confirmPassword.length > 0 && (
+                <span className="text-red-400 text-[12px] ml-1">비밀번호가 일치하지 않습니다.</span>
+              )}
+            </label>
+
+            {feedback !== 'idle' && (
+              <p className={`text-center text-[14px] ${feedback === 'error' ? 'text-red-400' : 'text-emerald-400'}`}>
+                {message}
+              </p>
+            )}
+
+            <button
+              className="w-full h-[56px] rounded-[16px] text-white text-[16px] font-bold tracking-tight transition-transform active:scale-[0.98] cursor-pointer border-none shadow-[0_4px_14px_0_rgba(43,127,255,0.4)] disabled:opacity-50 disabled:cursor-not-allowed"
+              type="submit"
+              disabled={!isPasswordValid || !isPasswordMatch || isLoading}
+              style={{ background: 'linear-gradient(90deg, #2B7FFF 0%, #9810FA 100%)' }}
+            >
+              {isLoading ? '변경 중...' : '완료'}
+            </button>
+          </form>
+        )}
+
+      </div>
+    </div>
+  )
+}

--- a/client-service/src/features/auth/components/VerificationInput.tsx
+++ b/client-service/src/features/auth/components/VerificationInput.tsx
@@ -1,0 +1,83 @@
+import { useRef, type ChangeEvent, type KeyboardEvent, type ClipboardEvent } from 'react'
+
+interface VerificationInputProps {
+  value: string
+  onChange: (value: string) => void
+  disabled?: boolean
+}
+
+export function VerificationInput({ value, onChange, disabled }: VerificationInputProps) {
+  const inputs = useRef<(HTMLInputElement | null)[]>([])
+
+  const handleChange = (index: number, e: ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value
+    // Allow only numeric input
+    if (val && !/^[0-9]$/.test(val)) return
+
+    const newCode = value.split('')
+    // If value length is less than current index (shouldn't happen if controlled correctly but safety check)
+    while (newCode.length < index) newCode.push('')
+    
+    newCode[index] = val
+    const newValue = newCode.join('').slice(0, 6)
+    
+    onChange(newValue)
+
+    // Move to next input if value entered
+    if (val && index < 5) {
+      inputs.current[index + 1]?.focus()
+    }
+  }
+
+  const handleKeyDown = (index: number, e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Backspace') {
+      if (!value[index] && index > 0) {
+        // If current is empty, move back and delete that one?
+        // Standard behavior: just move focus back.
+        inputs.current[index - 1]?.focus()
+         e.preventDefault() // prevent default backspace which might do nothing here
+      } else if (value[index]) {
+         // If has value, let default behavior happen (delete char)
+         // But we need to ensure state updates. default behavior on controlled input needs onChange.
+         // Actually, if we rely on onChange for deletion it works.
+         // However, if we want "Backspace deletes and moves back" vs "Backspace deletes in place".
+         // Let's rely on standard input behavior for deletion (will trigger onChange with empty string).
+      }
+    }
+  }
+
+  const handlePaste = (e: ClipboardEvent<HTMLInputElement>) => {
+    e.preventDefault()
+    const pastedData = e.clipboardData.getData('text').replace(/[^0-9]/g, '').slice(0, 6)
+    if (pastedData) {
+      onChange(pastedData)
+      // Focus the input after the last pasted character
+      const nextIndex = Math.min(pastedData.length, 5)
+      inputs.current[nextIndex]?.focus()
+    }
+  }
+
+  return (
+    <div className="flex gap-2 justify-between w-full">
+      {[0, 1, 2, 3, 4, 5].map((index) => (
+        <div 
+          key={index} 
+          className="w-[48px] h-[52px] bg-[#1E293B] rounded-[16px] border border-transparent focus-within:border-[#2B7FFF] transition-colors flex items-center justify-center relative"
+        >
+          <input
+            ref={(el) => { inputs.current[index] = el }}
+            type="text"
+            inputMode="numeric"
+            maxLength={1}
+            value={value[index] || ''}
+            onChange={(e) => handleChange(index, e)}
+            onKeyDown={(e) => handleKeyDown(index, e)}
+            onPaste={handlePaste}
+            disabled={disabled}
+            className="bg-transparent border-none text-white text-[20px] font-bold w-full h-full text-center focus:outline-none disabled:opacity-50 p-0 caret-[#2B7FFF]"
+          />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/client-service/src/features/auth/index.ts
+++ b/client-service/src/features/auth/index.ts
@@ -1,4 +1,5 @@
 export { LoginPage } from './LoginPage'
 export { SignupPage } from './SignupPage'
+export { PasswordResetPage } from './PasswordResetPage'
 export { AuthProvider } from './AuthContext'
 export { useAuth } from './AuthContextDefinition'

--- a/client-service/src/routes/AppRouter.tsx
+++ b/client-service/src/routes/AppRouter.tsx
@@ -1,7 +1,7 @@
 import { Suspense, useEffect, type ReactNode } from 'react'
 import { BrowserRouter, Link, Navigate, Route, Routes, useLocation } from 'react-router-dom'
 import { Toaster } from 'react-hot-toast'
-import { LoginPage, SignupPage, useAuth } from '../features/auth'
+import { LoginPage, PasswordResetPage, SignupPage, useAuth } from '../features/auth'
 import { MainPage } from '../features/home'
 import { ExplorePage } from '../features/explore'
 import { BookmarksPage } from '../features/bookmarks'
@@ -118,6 +118,7 @@ export function AppRouter() {
           />
           <Route path="/login" element={<LoginPage />} />
           <Route path="/signup" element={<SignupPage />} />
+          <Route path="/password-reset" element={<PasswordResetPage />} />
           <Route
             path="*"
             element={

--- a/client-service/src/services/authApi.ts
+++ b/client-service/src/services/authApi.ts
@@ -29,6 +29,21 @@ export type LoginResponse = {
   data: LoginResponseData
 }
 
+export type VerificationStatus = 'PENDING' | 'VERIFIED' | 'EXPIRED' | 'LOCKED'
+
+export type VerificationResponseData = {
+  status: VerificationStatus
+  attempts: number
+  retryAt: string | null
+  expiresAt: string
+}
+
+export type VerificationResponse = {
+  status: string
+  message: string
+  data: VerificationResponseData
+}
+
 export const authApi = {
   login(payload: LoginPayload) {
     return apiClient.request<LoginResponse>('/auth/login', {
@@ -42,13 +57,13 @@ export const authApi = {
     })
   },
   sendVerificationCode(email: string) {
-    return apiClient.request<{ success: boolean }>('/auth/email-verification/request', {
+    return apiClient.request<{ status: string; message: string; data: null }>('/auth/password-reset/request', {
       method: 'POST',
       body: { email },
     })
   },
   confirmVerificationCode(email: string, code: string) {
-    return apiClient.request<{ success: boolean }>('/auth/email-verification/confirm', {
+    return apiClient.request<VerificationResponse>('/auth/password-reset/verify', {
       method: 'POST',
       body: { email, code },
     })
@@ -59,8 +74,8 @@ export const authApi = {
       body: payload,
     })
   },
-  resetPassword(payload: { email: string; code: string; password: string }) {
-    return apiClient.request<{ success: boolean }>('/auth/password-reset', {
+  resetPassword(payload: { email: string; newPassword: string; confirmPassword: string }) {
+    return apiClient.request<{ status: string; message: string; data: null }>('/auth/password-reset/confirm', {
       method: 'POST',
       body: payload,
     })

--- a/client-service/src/services/authApi.ts
+++ b/client-service/src/services/authApi.ts
@@ -59,4 +59,10 @@ export const authApi = {
       body: payload,
     })
   },
+  resetPassword(payload: { email: string; code: string; password: string }) {
+    return apiClient.request<{ success: boolean }>('/auth/password-reset', {
+      method: 'POST',
+      body: payload,
+    })
+  },
 }

--- a/identity-service/README.md
+++ b/identity-service/README.md
@@ -1,1 +1,718 @@
-ArgoCD 배포 테스트 17:45
+# Identity Service
+
+**Key Feed** 시스템의 사용자 인증 및 사용자 설정을 담당하는 마이크로서비스입니다.
+
+## 기술 스택
+
+- **Java 17**
+- **Spring Boot 3.5**
+- **Spring Security** - JWT 기반 인증
+- **Spring Data JPA** - 데이터 액세스
+- **Spring Cloud Netflix Eureka** - 서비스 디스커버리
+- **Spring Cloud OpenFeign** - 서비스 간 통신
+- **MySQL** - 데이터베이스
+- **Jasypt** - 속성 암호화
+- **Thymeleaf** - 이메일 템플릿
+
+## 아키텍처
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      API Gateway                            │
+│              (JWT 검증 → X-User-Id 헤더 추가)                  │
+└─────────────────────────────┬───────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    Identity Service                         │
+│                       (Port: 8081)                          │
+├─────────────────────────────────────────────────────────────┤
+│  ┌─────────┐  ┌─────────┐  ┌─────────┐  ┌─────────────────┐ │
+│  │  Auth   │  │ Keyword │  │ Source  │  │    Bookmark     │ │
+│  │ Domain  │  │ Domain  │  │ Domain  │  │     Domain      │ │
+│  └─────────┘  └─────────┘  └─────────┘  └─────────────────┘ │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## 도메인 구조
+
+| 도메인 | 설명 |
+|--------|------|
+| **Auth** | 회원가입, 로그인, JWT 토큰 관리, 이메일 인증, 비밀번호 관리 |
+| **Keyword** | 사용자 키워드 관리, 알림 토글 |
+| **Source** | RSS/피드 소스 구독 관리 |
+| **Bookmark** | 북마크 및 폴더 관리 |
+
+## 빌드 및 실행
+
+### 필수 환경변수
+
+| 변수명 | 설명 |
+|--------|------|
+| `jwt_key` | JWT 서명용 HMAC512 시크릿 |
+| `jasypt_key` | application.yml의 `ENC()` 값 복호화 키 |
+
+### 빌드
+
+```bash
+# 빌드 (테스트 생략)
+./gradlew clean build -x test
+
+# 전체 테스트 실행
+./gradlew test
+```
+
+### 실행
+
+```bash
+# 로컬 실행
+./gradlew bootRun --args='--spring.profiles.active=local'
+```
+
+## 프로필
+
+| 프로필 | 설명 |
+|--------|------|
+| `local` | MySQL localhost, 개발용 JWT 만료시간 연장 |
+| `prod` | 외부 DB, 표준 JWT 만료시간 (기본) |
+
+## 인증 흐름
+
+### JWT 토큰
+- **Access Token**: 10분 만료
+- **Refresh Token**: 14일 만료 (HTTP-only 쿠키)
+
+### 엔드포인트 접근 권한
+- **공개**: `/api/auth/**` (회원가입, 로그인, 이메일 인증, 비밀번호 찾기)
+- **인증 필요**: `/api/users/**`, `/api/keywords/**`, `/api/sources/**`, `/api/bookmarks/**`
+- **내부 전용**: `/internal/**`, `/actuator/**`
+
+---
+
+# API 명세
+
+## 공통 응답 형식
+
+```json
+{
+  "status": "200",
+  "message": "성공 메시지",
+  "data": { ... }
+}
+```
+
+---
+
+## 1. 인증 API (`/api/auth`)
+
+### 1.1 회원가입
+
+**POST** `/api/auth/join`
+
+```json
+// Request
+{
+  "email": "user@example.com",
+  "name": "홍길동",
+  "password": "password123"
+}
+
+// Response (201 Created)
+{
+  "status": "201",
+  "message": "저장에 성공하였습니다.",
+  "data": null
+}
+```
+
+### 1.2 로그인
+
+**POST** `/api/auth/login`
+
+```json
+// Request
+{
+  "email": "user@example.com",
+  "password": "password123"
+}
+
+// Response (200 OK)
+// Set-Cookie: refreshToken=xxx; HttpOnly; SameSite=None; Path=/
+{
+  "status": "200",
+  "message": "로그인에 성공하였습니다.",
+  "data": {
+    "id": 1,
+    "email": "user@example.com",
+    "name": "홍길동",
+    "role": "USER",
+    "accessToken": "eyJhbGciOiJIUzUxMi..."
+  }
+}
+```
+
+### 1.3 토큰 재발급
+
+**POST** `/api/auth/refresh`
+
+> Cookie에 `refreshToken` 필요
+
+```json
+// Response (200 OK)
+// Set-Cookie: refreshToken=xxx; HttpOnly; SameSite=None; Path=/
+{
+  "status": "200",
+  "message": "토큰발급에 성공했습니다.",
+  "data": "eyJhbGciOiJIUzUxMi..."  // 새 accessToken
+}
+```
+
+### 1.4 회원가입 이메일 인증 요청
+
+**POST** `/api/auth/email-verification/request`
+
+```json
+// Request
+{
+  "email": "user@example.com"
+}
+
+// Response (201 Created)
+{
+  "status": "201",
+  "message": "이메일 전송에 성공하였습니다.",
+  "data": null
+}
+```
+
+### 1.5 회원가입 이메일 인증 확인
+
+**POST** `/api/auth/email-verification/confirm`
+
+```json
+// Request
+{
+  "email": "user@example.com",
+  "code": "123456"
+}
+
+// Response (200 OK)
+{
+  "status": "200",
+  "message": "이메일 인증이 완료되었습니다.",  // 또는 "인증번호가 일치하지 않습니다."
+  "data": {
+    "status": "VERIFIED",  // PENDING, VERIFIED, EXPIRED, LOCKED
+    "attempts": 1,
+    "retryAt": null,
+    "expiresAt": "2026-02-05T16:15:00"
+  }
+}
+```
+
+### 1.6 비밀번호 찾기 - 이메일 요청
+
+**POST** `/api/auth/password-reset/request`
+
+```json
+// Request
+{
+  "email": "user@example.com"
+}
+
+// Response (201 Created)
+{
+  "status": "201",
+  "message": "비밀번호 재설정을 위한 인증 이메일이 발송되었습니다.",
+  "data": null
+}
+```
+
+| 에러 상황 | HTTP Status | message |
+|----------|-------------|---------|
+| 등록되지 않은 이메일 | 404 | 데이터가 존재하지 않습니다. |
+| 잠금 상태 | 423 | 일정 시간 동안 많은 시도로 인해 인증이 제한되었습니다. |
+
+### 1.7 비밀번호 찾기 - 인증코드 검증
+
+**POST** `/api/auth/password-reset/verify`
+
+```json
+// Request
+{
+  "email": "user@example.com",
+  "code": "123456"
+}
+
+// Response (200 OK)
+{
+  "status": "200",
+  "message": "이메일 인증이 완료되었습니다.",
+  "data": {
+    "status": "VERIFIED",
+    "attempts": 1,
+    "retryAt": null,
+    "expiresAt": "2026-02-05T16:15:00"
+  }
+}
+```
+
+| 에러 상황 | HTTP Status | message |
+|----------|-------------|---------|
+| 코드 만료 | 400 | 인증코드의 유효기간이 지났습니다. |
+| 시도 횟수 초과 | 429 | 지정된 인증 횟수가 초과되었습니다. |
+| 잠금 상태 | 423 | 일정 시간 동안 많은 시도로 인해 인증이 제한되었습니다. |
+
+### 1.8 비밀번호 찾기 - 비밀번호 재설정
+
+**POST** `/api/auth/password-reset/confirm`
+
+```json
+// Request
+{
+  "email": "user@example.com",
+  "newPassword": "newPassword123!",
+  "confirmPassword": "newPassword123!"
+}
+
+// Response (200 OK)
+{
+  "status": "200",
+  "message": "비밀번호가 성공적으로 재설정되었습니다.",
+  "data": null
+}
+```
+
+| 에러 상황 | HTTP Status | message |
+|----------|-------------|---------|
+| 비밀번호 불일치 | 400 | 새 비밀번호가 일치하지 않습니다. |
+| 이메일 인증 미완료 | 400 | 이메일 인증이 완료되지 않았습니다. |
+| 기존 비밀번호와 동일 | 400 | 현재 비밀번호와 동일한 비밀번호로 변경할 수 없습니다. |
+
+---
+
+## 2. 사용자 API (`/api/users`)
+
+> 인증 필요 (X-User-Id 헤더)
+
+### 2.1 비밀번호 변경
+
+**PATCH** `/api/users/password`
+
+```json
+// Request
+{
+  "currentPassword": "oldPassword123",
+  "newPassword": "newPassword123!",
+  "confirmPassword": "newPassword123!"
+}
+
+// Response (200 OK)
+{
+  "status": "200",
+  "message": "비밀번호가 성공적으로 변경되었습니다.",
+  "data": null
+}
+```
+
+### 2.2 회원 탈퇴
+
+**DELETE** `/api/users`
+
+```json
+// Request
+{
+  "password": "password123"
+}
+
+// Response (200 OK)
+{
+  "status": "200",
+  "message": "회원 탈퇴가 완료되었습니다.",
+  "data": null
+}
+```
+
+---
+
+## 3. 키워드 API (`/api/keywords`)
+
+> 인증 필요 (X-User-Id 헤더)
+
+### 3.1 키워드 목록 조회
+
+**GET** `/api/keywords`
+
+```json
+// Response (200 OK)
+{
+  "status": "200",
+  "message": "조회에 성공하였습니다.",
+  "data": [
+    {
+      "id": 1,
+      "name": "AI",
+      "notificationEnabled": true
+    }
+  ]
+}
+```
+
+### 3.2 키워드 추가
+
+**POST** `/api/keywords`
+
+```json
+// Request
+{
+  "name": "AI"
+}
+
+// Response (201 Created)
+{
+  "status": "201",
+  "message": "저장에 성공하였습니다.",
+  "data": {
+    "id": 1,
+    "name": "AI",
+    "notificationEnabled": true
+  }
+}
+```
+
+### 3.3 키워드 알림 토글
+
+**PATCH** `/api/keywords/{keywordId}/toggle`
+
+```json
+// Response (200 OK)
+{
+  "status": "200",
+  "message": "수정에 성공하였습니다.",
+  "data": {
+    "id": 1,
+    "name": "AI",
+    "notificationEnabled": false
+  }
+}
+```
+
+### 3.4 키워드 삭제
+
+**DELETE** `/api/keywords/{keywordId}`
+
+```json
+// Response (200 OK)
+{
+  "status": "200",
+  "message": "삭제에 성공하였습니다.",
+  "data": null
+}
+```
+
+---
+
+## 4. 소스 API (`/api/sources`)
+
+> 인증 필요 (X-User-Id 헤더)
+
+### 4.1 내 소스 목록 조회
+
+**GET** `/api/sources/my`
+
+```json
+// Response (200 OK)
+{
+  "status": "200",
+  "message": "조회에 성공하였습니다.",
+  "data": [
+    {
+      "userSourceId": 1,
+      "sourceId": 10,
+      "name": "TechCrunch",
+      "url": "https://techcrunch.com/feed",
+      "receiveFeed": true
+    }
+  ]
+}
+```
+
+### 4.2 내 소스 검색
+
+**GET** `/api/sources/my/search?keyword={keyword}`
+
+```json
+// Response (200 OK)
+{
+  "status": "200",
+  "message": "조회에 성공하였습니다.",
+  "data": [ ... ]
+}
+```
+
+### 4.3 소스 추가
+
+**POST** `/api/sources`
+
+```json
+// Request
+{
+  "url": "https://techcrunch.com/feed",
+  "name": "TechCrunch"
+}
+
+// Response (200 OK)
+{
+  "status": "200",
+  "message": "저장에 성공하였습니다.",
+  "data": {
+    "userSourceId": 1,
+    "sourceId": 10,
+    "name": "TechCrunch",
+    "url": "https://techcrunch.com/feed",
+    "receiveFeed": true
+  }
+}
+```
+
+### 4.4 소스 구독 해제
+
+**DELETE** `/api/sources/my/{userSourceId}`
+
+```json
+// Response (200 OK)
+{
+  "status": "200",
+  "message": "삭제에 성공하였습니다.",
+  "data": null
+}
+```
+
+### 4.5 피드 수신 토글
+
+**PATCH** `/api/sources/my/{userSourceId}/receive-feed`
+
+```json
+// Response (200 OK)
+{
+  "status": "200",
+  "message": "수정에 성공하였습니다.",
+  "data": {
+    "userSourceId": 1,
+    "sourceId": 10,
+    "name": "TechCrunch",
+    "url": "https://techcrunch.com/feed",
+    "receiveFeed": false
+  }
+}
+```
+
+### 4.6 추천 소스 목록 조회
+
+**GET** `/api/sources/recommended?page={page}&size={size}`
+
+```json
+// Response (200 OK)
+{
+  "status": "200",
+  "message": "조회에 성공하였습니다.",
+  "data": [
+    {
+      "sourceId": 10,
+      "name": "TechCrunch",
+      "url": "https://techcrunch.com/feed",
+      "subscribed": false
+    }
+  ]
+}
+```
+
+---
+
+## 5. 북마크 API (`/api/bookmarks`)
+
+> 인증 필요 (X-User-Id 헤더)
+
+### 5.1 북마크 폴더 목록 조회
+
+**GET** `/api/bookmarks/folders`
+
+```json
+// Response (200 OK)
+{
+  "status": "200",
+  "message": "조회에 성공하였습니다.",
+  "data": [
+    {
+      "id": 1,
+      "name": "개발",
+      "bookmarkCount": 5
+    }
+  ]
+}
+```
+
+### 5.2 북마크 폴더 생성
+
+**POST** `/api/bookmarks/folders`
+
+```json
+// Request
+{
+  "name": "개발"
+}
+
+// Response (201 Created)
+{
+  "status": "201",
+  "message": "저장에 성공하였습니다.",
+  "data": 1  // folderId
+}
+```
+
+### 5.3 북마크 폴더 수정
+
+**PATCH** `/api/bookmarks/folders/{folderId}`
+
+```json
+// Request
+{
+  "name": "개발 자료"
+}
+
+// Response (200 OK)
+{
+  "status": "200",
+  "message": "수정에 성공하였습니다.",
+  "data": null
+}
+```
+
+### 5.4 북마크 폴더 삭제
+
+**DELETE** `/api/bookmarks/folders/{folderId}`
+
+```json
+// Response (200 OK)
+{
+  "status": "200",
+  "message": "삭제에 성공하였습니다.",
+  "data": null
+}
+```
+
+### 5.5 북마크 목록 조회
+
+**GET** `/api/bookmarks?folderId={folderId}&lastId={lastId}&size={size}`
+
+> 커서 기반 페이지네이션
+
+```json
+// Response (200 OK)
+{
+  "status": "200",
+  "message": "조회에 성공하였습니다.",
+  "data": {
+    "content": [
+      {
+        "id": 1,
+        "contentId": "content-123",
+        "title": "기사 제목",
+        "url": "https://example.com/article",
+        "folderId": 1
+      }
+    ],
+    "lastId": 1,
+    "hasNext": true
+  }
+}
+```
+
+### 5.6 북마크 추가
+
+**POST** `/api/bookmarks`
+
+```json
+// Request
+{
+  "contentId": "content-123",
+  "title": "기사 제목",
+  "url": "https://example.com/article",
+  "folderId": 1  // optional
+}
+
+// Response (201 Created)
+{
+  "status": "201",
+  "message": "저장에 성공하였습니다.",
+  "data": 1  // bookmarkId
+}
+```
+
+### 5.7 북마크 삭제
+
+**DELETE** `/api/bookmarks/{bookmarkId}`
+
+```json
+// Response (200 OK)
+{
+  "status": "200",
+  "message": "삭제에 성공하였습니다.",
+  "data": null
+}
+```
+
+### 5.8 북마크 폴더 이동
+
+**PATCH** `/api/bookmarks/{bookmarkId}/folder`
+
+```json
+// Request
+{
+  "folderId": 2
+}
+
+// Response (200 OK)
+{
+  "status": "200",
+  "message": "수정에 성공하였습니다.",
+  "data": null
+}
+```
+
+### 5.9 북마크를 폴더에서 제거
+
+**DELETE** `/api/bookmarks/{bookmarkId}/folder`
+
+```json
+// Response (200 OK)
+{
+  "status": "200",
+  "message": "수정에 성공하였습니다.",
+  "data": null
+}
+```
+
+---
+
+## 6. 내부 API (`/internal`)
+
+> 서비스 간 통신용 (인증 없음)
+
+| Method | URL | 설명 |
+|--------|-----|------|
+| GET | `/internal/users/{userId}/keywords` | 사용자 키워드 조회 |
+| POST | `/internal/keywords/match-users?sourceId={sourceId}` | 키워드 매칭 사용자 조회 |
+| GET | `/internal/sources/user/{userId}` | 사용자 구독 소스 조회 |
+| POST | `/internal/bookmarks/user/{userId}/check` | 북마크 여부 확인 |
+
+---
+
+## 제한 사항
+
+| 항목 | 제한 |
+|------|------|
+| 사용자당 최대 키워드 | 20개 |
+| 사용자당 최대 북마크 폴더 | 7개 |
+| 이메일 인증 최대 시도 | 5회 |
+| 이메일 인증 잠금 시간 | 15분 |
+| 인증 코드 유효 시간 | 5분 |

--- a/identity-service/src/main/java/com/leedahun/identityservice/common/message/ErrorMessage.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/common/message/ErrorMessage.java
@@ -50,7 +50,10 @@ public enum ErrorMessage {
 
     // 비밀번호 변경 관련 에러 메시지
     PASSWORD_MISMATCH("새 비밀번호가 일치하지 않습니다."),
-    SAME_PASSWORD("현재 비밀번호와 동일한 비밀번호로 변경할 수 없습니다.");
+    SAME_PASSWORD("현재 비밀번호와 동일한 비밀번호로 변경할 수 없습니다."),
+
+    // 비밀번호 재설정 관련 에러 메시지
+    EMAIL_VERIFICATION_REQUIRED("이메일 인증이 완료되지 않았습니다.");
 
     private final String message;
 }

--- a/identity-service/src/main/java/com/leedahun/identityservice/common/message/SuccessMessage.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/common/message/SuccessMessage.java
@@ -21,7 +21,10 @@ public enum SuccessMessage {
 
     PASSWORD_CHANGE_SUCCESS("비밀번호가 성공적으로 변경되었습니다."),
 
-    WITHDRAW_SUCCESS("회원 탈퇴가 완료되었습니다.");
+    WITHDRAW_SUCCESS("회원 탈퇴가 완료되었습니다."),
+
+    PASSWORD_RESET_EMAIL_SENT("비밀번호 재설정을 위한 인증 이메일이 발송되었습니다."),
+    PASSWORD_RESET_SUCCESS("비밀번호가 성공적으로 재설정되었습니다.");
 
     private final String message;
 }

--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/controller/AuthController.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/controller/AuthController.java
@@ -10,11 +10,15 @@ import com.leedahun.identityservice.domain.auth.dto.EmailVerificationSendRequest
 import com.leedahun.identityservice.domain.auth.dto.JoinRequestDto;
 import com.leedahun.identityservice.domain.auth.dto.LoginRequestDto;
 import com.leedahun.identityservice.domain.auth.dto.LoginResult;
+import com.leedahun.identityservice.domain.auth.dto.PasswordResetConfirmRequestDto;
+import com.leedahun.identityservice.domain.auth.dto.PasswordResetRequestDto;
+import com.leedahun.identityservice.domain.auth.dto.PasswordResetVerifyRequestDto;
 import com.leedahun.identityservice.domain.auth.dto.TokenResult;
 import com.leedahun.identityservice.domain.auth.entity.EmailVerifyStatus;
 import com.leedahun.identityservice.domain.auth.exception.RefreshTokenNotExistsException;
 import com.leedahun.identityservice.domain.auth.service.JoinService;
 import com.leedahun.identityservice.domain.auth.service.LoginService;
+import com.leedahun.identityservice.domain.auth.service.PasswordResetService;
 import com.leedahun.identityservice.domain.auth.util.CookieUtil;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +39,7 @@ public class AuthController {
 
     private final LoginService loginService;
     private final JoinService joinService;
+    private final PasswordResetService passwordResetService;
     private final JwtProperties jwtProperties;
 
     @PostMapping("/join")
@@ -88,6 +93,37 @@ public class AuthController {
         return ResponseEntity
                 .ok()
                 .body(new HttpResponse(HttpStatus.OK, message, emailVerificationResult));
+    }
+
+    @PostMapping("/password-reset/request")
+    public ResponseEntity<?> requestPasswordReset(@RequestBody PasswordResetRequestDto requestDto) {
+        passwordResetService.requestPasswordReset(requestDto);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(new HttpResponse(HttpStatus.CREATED, SuccessMessage.PASSWORD_RESET_EMAIL_SENT.getMessage(), null));
+    }
+
+    @PostMapping("/password-reset/verify")
+    public ResponseEntity<?> verifyPasswordResetCode(@RequestBody PasswordResetVerifyRequestDto requestDto) {
+        EmailVerificationConfirmResponseDto result = passwordResetService.verifyCode(requestDto);
+
+        String message;
+        if (result.getStatus() == EmailVerifyStatus.VERIFIED) {
+            message = SuccessMessage.EMAIL_VERIFIED.getMessage();
+        } else {
+            message = ErrorMessage.EMAIL_VERIFICATION_FAILED.getMessage();
+        }
+        return ResponseEntity
+                .ok()
+                .body(new HttpResponse(HttpStatus.OK, message, result));
+    }
+
+    @PostMapping("/password-reset/confirm")
+    public ResponseEntity<?> confirmPasswordReset(@RequestBody PasswordResetConfirmRequestDto requestDto) {
+        passwordResetService.resetPassword(requestDto);
+        return ResponseEntity
+                .ok()
+                .body(new HttpResponse(HttpStatus.OK, SuccessMessage.PASSWORD_RESET_SUCCESS.getMessage(), null));
     }
 
 }

--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/dto/PasswordResetConfirmRequestDto.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/dto/PasswordResetConfirmRequestDto.java
@@ -1,0 +1,18 @@
+package com.leedahun.identityservice.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordResetConfirmRequestDto {
+    private String email;
+    private String newPassword;
+    private String confirmPassword;
+}

--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/dto/PasswordResetRequestDto.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/dto/PasswordResetRequestDto.java
@@ -1,0 +1,16 @@
+package com.leedahun.identityservice.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordResetRequestDto {
+    private String email;
+}

--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/dto/PasswordResetVerifyRequestDto.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/dto/PasswordResetVerifyRequestDto.java
@@ -1,0 +1,17 @@
+package com.leedahun.identityservice.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordResetVerifyRequestDto {
+    private String email;
+    private String code;
+}

--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/exception/EmailVerificationRequiredException.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/exception/EmailVerificationRequiredException.java
@@ -1,0 +1,13 @@
+package com.leedahun.identityservice.domain.auth.exception;
+
+import com.leedahun.identityservice.common.error.exception.CustomException;
+import com.leedahun.identityservice.common.message.ErrorMessage;
+import org.springframework.http.HttpStatus;
+
+public class EmailVerificationRequiredException extends CustomException {
+
+    public EmailVerificationRequiredException() {
+        super(ErrorMessage.EMAIL_VERIFICATION_REQUIRED.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+}

--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/service/EmailVerificationService.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/service/EmailVerificationService.java
@@ -1,0 +1,39 @@
+package com.leedahun.identityservice.domain.auth.service;
+
+import com.leedahun.identityservice.domain.auth.dto.EmailVerificationConfirmResponseDto;
+import com.leedahun.identityservice.domain.auth.entity.EmailPurpose;
+
+public interface EmailVerificationService {
+
+    /**
+     * 이메일 인증 코드 발송
+     * @param email 수신자 이메일
+     * @param purpose 인증 목적 (SIGNUP, RESET, CHANGE)
+     * @param subject 이메일 제목
+     */
+    void sendVerificationEmail(String email, EmailPurpose purpose, String subject);
+
+    /**
+     * 이메일 인증 코드 검증
+     * @param email 이메일
+     * @param code 인증 코드
+     * @param purpose 인증 목적
+     * @return 인증 결과
+     */
+    EmailVerificationConfirmResponseDto verifyCode(String email, String code, EmailPurpose purpose);
+
+    /**
+     * 이메일 인증 완료 여부 확인
+     * @param email 이메일
+     * @param purpose 인증 목적
+     * @return 인증 완료 여부
+     */
+    boolean isVerified(String email, EmailPurpose purpose);
+
+    /**
+     * 인증 완료된 레코드 삭제 (비밀번호 재설정 완료 후 정리)
+     * @param email 이메일
+     * @param purpose 인증 목적
+     */
+    void deleteVerification(String email, EmailPurpose purpose);
+}

--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/service/PasswordResetService.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/service/PasswordResetService.java
@@ -1,0 +1,28 @@
+package com.leedahun.identityservice.domain.auth.service;
+
+import com.leedahun.identityservice.domain.auth.dto.EmailVerificationConfirmResponseDto;
+import com.leedahun.identityservice.domain.auth.dto.PasswordResetConfirmRequestDto;
+import com.leedahun.identityservice.domain.auth.dto.PasswordResetRequestDto;
+import com.leedahun.identityservice.domain.auth.dto.PasswordResetVerifyRequestDto;
+
+public interface PasswordResetService {
+
+    /**
+     * 비밀번호 재설정을 위한 인증 이메일 발송
+     * @param requestDto 이메일 주소
+     */
+    void requestPasswordReset(PasswordResetRequestDto requestDto);
+
+    /**
+     * 인증 코드 검증
+     * @param requestDto 이메일, 인증 코드
+     * @return 인증 결과
+     */
+    EmailVerificationConfirmResponseDto verifyCode(PasswordResetVerifyRequestDto requestDto);
+
+    /**
+     * 비밀번호 재설정 완료
+     * @param requestDto 이메일, 새 비밀번호, 비밀번호 확인
+     */
+    void resetPassword(PasswordResetConfirmRequestDto requestDto);
+}

--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/service/impl/EmailVerificationServiceImpl.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/service/impl/EmailVerificationServiceImpl.java
@@ -1,0 +1,196 @@
+package com.leedahun.identityservice.domain.auth.service.impl;
+
+import com.leedahun.identityservice.common.error.exception.EntityNotFoundException;
+import com.leedahun.identityservice.common.mail.EmailClient;
+import com.leedahun.identityservice.domain.auth.dto.EmailVerificationConfirmResponseDto;
+import com.leedahun.identityservice.domain.auth.entity.EmailPurpose;
+import com.leedahun.identityservice.domain.auth.entity.EmailVerification;
+import com.leedahun.identityservice.domain.auth.entity.EmailVerifyStatus;
+import com.leedahun.identityservice.domain.auth.exception.EmailVerificationAlreadyDoneException;
+import com.leedahun.identityservice.domain.auth.exception.EmailVerificationAttemptLimitExceededException;
+import com.leedahun.identityservice.domain.auth.exception.EmailVerificationExpiredException;
+import com.leedahun.identityservice.domain.auth.exception.EmailVerificationLockedException;
+import com.leedahun.identityservice.domain.auth.repository.EmailVerificationRepository;
+import com.leedahun.identityservice.domain.auth.service.EmailVerificationService;
+import com.leedahun.identityservice.domain.auth.util.VerificationCodeUtil;
+import java.time.LocalDateTime;
+import java.time.Year;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class EmailVerificationServiceImpl implements EmailVerificationService {
+
+    @Value("${spring.mail.lock_minutes}")
+    private int lockMinutes;
+
+    @Value("${spring.mail.expire_minutes}")
+    private int expireMinutes;
+
+    @Value("${spring.mail.max_attempts}")
+    private int maxAttempts;
+
+    private final EmailVerificationRepository emailVerificationRepository;
+    private final SpringTemplateEngine templateEngine;
+    private final EmailClient emailClient;
+
+    @Override
+    public void sendVerificationEmail(String email, EmailPurpose purpose, String subject) {
+        String code = VerificationCodeUtil.generateEmailVerificationCode();
+        final LocalDateTime now = LocalDateTime.now();
+
+        Optional<EmailVerification> optionalEmailVerification =
+                emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(email, purpose);
+
+        if (optionalEmailVerification.isPresent()) {
+            handleExistingEmailVerification(optionalEmailVerification.get(), code, now, purpose, subject);
+            return;
+        }
+
+        saveNewEmailVerification(email, code, now, purpose);
+        sendEmail(email, code, subject);
+    }
+
+    @Override
+    public EmailVerificationConfirmResponseDto verifyCode(String email, String code, EmailPurpose purpose) {
+        final LocalDateTime now = LocalDateTime.now();
+
+        EmailVerification emailVerification = emailVerificationRepository
+                .findTopByEmailAndPurposeOrderByIdDesc(email, purpose)
+                .orElseThrow(() -> new EntityNotFoundException("EmailVerification", email));
+
+        if (emailVerification.getStatus().equals(EmailVerifyStatus.VERIFIED)) {
+            log.info("이메일이 이미 인증되었습니다. {}", email);
+            return EmailVerificationConfirmResponseDto.from(emailVerification);
+        }
+
+        if (emailVerification.getStatus() == EmailVerifyStatus.LOCKED) {
+            LocalDateTime lockUntil = emailVerification.getLockedUntil();
+
+            if (lockUntil != null && now.isBefore(lockUntil)) {
+                throw new EmailVerificationLockedException();
+            }
+
+            emailVerification.updateStatus(EmailVerifyStatus.PENDING);
+            emailVerification.resetAttemptCount();
+        }
+
+        if (emailVerification.getExpiresAt().isBefore(now)) {
+            emailVerification.updateStatus(EmailVerifyStatus.EXPIRED);
+            emailVerificationRepository.save(emailVerification);
+            throw new EmailVerificationExpiredException();
+        }
+
+        if (emailVerification.getCode().equals(code)) {
+            emailVerification.updateStatus(EmailVerifyStatus.VERIFIED);
+            emailVerificationRepository.save(emailVerification);
+            return EmailVerificationConfirmResponseDto.from(emailVerification);
+        }
+
+        emailVerification.increaseAttemptCount();
+
+        if (emailVerification.getAttemptCount() >= maxAttempts) {
+            emailVerification.updateStatus(EmailVerifyStatus.LOCKED);
+            emailVerification.updateLockedUntil(LocalDateTime.now().plusMinutes(lockMinutes));
+            emailVerificationRepository.save(emailVerification);
+
+            throw new EmailVerificationAttemptLimitExceededException();
+        }
+
+        emailVerificationRepository.save(emailVerification);
+
+        return EmailVerificationConfirmResponseDto.from(emailVerification);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean isVerified(String email, EmailPurpose purpose) {
+        return emailVerificationRepository
+                .findTopByEmailAndPurposeOrderByIdDesc(email, purpose)
+                .map(ev -> ev.getStatus() == EmailVerifyStatus.VERIFIED)
+                .orElse(false);
+    }
+
+    @Override
+    public void deleteVerification(String email, EmailPurpose purpose) {
+        emailVerificationRepository
+                .findTopByEmailAndPurposeOrderByIdDesc(email, purpose)
+                .ifPresent(emailVerificationRepository::delete);
+    }
+
+    private void handleExistingEmailVerification(EmailVerification emailVerification, String code,
+            LocalDateTime now, EmailPurpose purpose, String subject) {
+        String email = emailVerification.getEmail();
+
+        if (emailVerification.getStatus() == EmailVerifyStatus.VERIFIED) {
+            throw new EmailVerificationAlreadyDoneException();
+        } else if (emailVerification.getStatus() == EmailVerifyStatus.LOCKED) {
+            handleLockedEmailVerification(emailVerification, code, now);
+        } else if (emailVerification.getStatus() == EmailVerifyStatus.PENDING
+                && emailVerification.getExpiresAt().isAfter(now)) {
+            handleNotExpiredEmailVerification(emailVerification, code, now);
+        } else if (emailVerification.getExpiresAt().isBefore(now)) {
+            handleExpiredEmailVerification(emailVerification);
+            saveNewEmailVerification(email, code, now, purpose);
+        }
+
+        emailVerificationRepository.save(emailVerification);
+        sendEmail(email, code, subject);
+    }
+
+    private void handleLockedEmailVerification(EmailVerification emailVerification, String code, LocalDateTime now) {
+        if (emailVerification.getLockedUntil() != null && now.isBefore(emailVerification.getLockedUntil())) {
+            throw new EmailVerificationLockedException();
+        }
+        emailVerification.updateStatus(EmailVerifyStatus.PENDING);
+        emailVerification.updateCode(code);
+        emailVerification.resetAttemptCount();
+        emailVerification.clearLockedUntil();
+    }
+
+    private void handleNotExpiredEmailVerification(EmailVerification emailVerification, String code, LocalDateTime now) {
+        emailVerification.updateCode(code);
+        emailVerification.resetExpiresAt(now.plusMinutes(expireMinutes));
+    }
+
+    private void handleExpiredEmailVerification(EmailVerification emailVerification) {
+        emailVerification.updateStatus(EmailVerifyStatus.EXPIRED);
+    }
+
+    private String buildVerificationHtml(String email, String code) {
+        Context context = new Context();
+        context.setVariable("brandName", "Key Feed");
+        context.setVariable("email", email);
+        context.setVariable("code", code);
+        context.setVariable("expiresMinutes", expireMinutes);
+        context.setVariable("year", Year.now().getValue());
+
+        return templateEngine.process("email/verification", context);
+    }
+
+    private void sendEmail(String email, String code, String subject) {
+        String html = buildVerificationHtml(email, code);
+        emailClient.sendOneEmail(email, subject, html);
+    }
+
+    private EmailVerification saveNewEmailVerification(String email, String code, LocalDateTime now, EmailPurpose purpose) {
+        EmailVerification emailVerification = EmailVerification.builder()
+                .email(email)
+                .purpose(purpose)
+                .code(code)
+                .status(EmailVerifyStatus.PENDING)
+                .attemptCount(0)
+                .expiresAt(now.plusMinutes(expireMinutes))
+                .build();
+        return emailVerificationRepository.save(emailVerification);
+    }
+}

--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/service/impl/JoinServiceImpl.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/service/impl/JoinServiceImpl.java
@@ -1,34 +1,19 @@
 package com.leedahun.identityservice.domain.auth.service.impl;
 
-import com.leedahun.identityservice.common.error.exception.EntityNotFoundException;
-import com.leedahun.identityservice.common.mail.EmailClient;
 import com.leedahun.identityservice.domain.auth.dto.EmailVerificationConfirmRequestDto;
 import com.leedahun.identityservice.domain.auth.dto.EmailVerificationConfirmResponseDto;
 import com.leedahun.identityservice.domain.auth.dto.JoinRequestDto;
 import com.leedahun.identityservice.domain.auth.entity.EmailPurpose;
-import com.leedahun.identityservice.domain.auth.entity.EmailVerification;
-import com.leedahun.identityservice.domain.auth.entity.EmailVerifyStatus;
 import com.leedahun.identityservice.domain.auth.entity.User;
-import com.leedahun.identityservice.domain.auth.exception.EmailVerificationAlreadyDoneException;
-import com.leedahun.identityservice.domain.auth.exception.EmailVerificationAttemptLimitExceededException;
-import com.leedahun.identityservice.domain.auth.exception.EmailVerificationExpiredException;
-import com.leedahun.identityservice.domain.auth.exception.EmailVerificationLockedException;
 import com.leedahun.identityservice.domain.auth.exception.UserAlreadyExistsException;
-import com.leedahun.identityservice.domain.auth.repository.EmailVerificationRepository;
 import com.leedahun.identityservice.domain.auth.repository.UserRepository;
+import com.leedahun.identityservice.domain.auth.service.EmailVerificationService;
 import com.leedahun.identityservice.domain.auth.service.JoinService;
-import com.leedahun.identityservice.domain.auth.util.VerificationCodeUtil;
-import java.time.LocalDateTime;
-import java.time.Year;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.thymeleaf.context.Context;
-import org.thymeleaf.spring6.SpringTemplateEngine;
 
 @Slf4j
 @Service
@@ -36,22 +21,11 @@ import org.thymeleaf.spring6.SpringTemplateEngine;
 @RequiredArgsConstructor
 public class JoinServiceImpl implements JoinService {
 
-    @Value("${spring.mail.lock_minutes}")
-    private int lockMinutes;
+    private static final String SIGNUP_EMAIL_SUBJECT = "[Key Feed] 회원가입을 위한 이메일 인증번호입니다.";
 
-    @Value("${spring.mail.expire_minutes}")
-    private int expireMinutes;
-
-    @Value("${spring.mail.max_attempts}")
-    private int maxAttempts;
-
-    private static final String SUBJECT = "[Key Feed] 회원가입을 위한 이메일 인증번호입니다.";
-
-    private final EmailVerificationRepository emailVerificationRepository;
     private final UserRepository userRepository;
     private final BCryptPasswordEncoder passwordEncoder;
-    private final SpringTemplateEngine templateEngine;
-    private final EmailClient emailClient;
+    private final EmailVerificationService emailVerificationService;
 
     @Override
     @Transactional
@@ -67,131 +41,15 @@ public class JoinServiceImpl implements JoinService {
 
     @Override
     public void sendJoinEmail(String email) {
-        String code = VerificationCodeUtil.generateEmailVerificationCode();
-        final LocalDateTime now = LocalDateTime.now();
-
-        Optional<EmailVerification> optionalEmailVerification = emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(email, EmailPurpose.SIGNUP);
-        if (optionalEmailVerification.isPresent()) {
-            handleExistingEmailVerification(optionalEmailVerification.get(), code, now);
-            return;
-        }
-
-        saveNewEmailVerification(email, code, now);
-        sendJoinEmailVerificationEmail(email, code);
+        emailVerificationService.sendVerificationEmail(email, EmailPurpose.SIGNUP, SIGNUP_EMAIL_SUBJECT);
     }
 
-    private void handleExistingEmailVerification(EmailVerification emailVerification, String code, LocalDateTime now) {
-        String email = emailVerification.getEmail();
-        if (emailVerification.getStatus() == EmailVerifyStatus.VERIFIED) {
-            throw new EmailVerificationAlreadyDoneException();
-        } else if (emailVerification.getStatus() == EmailVerifyStatus.LOCKED) {
-            handleLockedEmailVerification(emailVerification, code, now);
-        } else if (emailVerification.getStatus() == EmailVerifyStatus.PENDING && emailVerification.getExpiresAt().isAfter(now)) {
-            handleNotExpiredEmailVerification(emailVerification, code, now);
-        } else if (emailVerification.getExpiresAt().isBefore(now)) {
-            handleExpiredEmailVerification(emailVerification);
-            saveNewEmailVerification(email, code, now);
-        }
-
-        emailVerificationRepository.save(emailVerification);
-        sendJoinEmailVerificationEmail(email, code);
-    }
-
-    private void handleLockedEmailVerification(EmailVerification emailVerification, String code, LocalDateTime now) {
-        if (emailVerification.getLockedUntil() != null && now.isBefore(emailVerification.getLockedUntil())) {
-            throw new EmailVerificationLockedException();
-        }
-        emailVerification.updateStatus(EmailVerifyStatus.PENDING);
-        emailVerification.updateCode(code);
-        emailVerification.resetAttemptCount();
-        emailVerification.clearLockedUntil();
-    }
-
-    private void handleNotExpiredEmailVerification(EmailVerification emailVerification, String code, LocalDateTime now) {
-        emailVerification.updateCode(code);
-        emailVerification.resetExpiresAt(now.plusMinutes(expireMinutes));
-    }
-
-    private void handleExpiredEmailVerification(EmailVerification emailVerification) {
-        emailVerification.updateStatus(EmailVerifyStatus.EXPIRED);
-    }
-
-    private String buildVerificationHtml(String email, String code) {
-        Context context = new Context();
-        context.setVariable("brandName", "Key Feed");
-        context.setVariable("email", email);
-        context.setVariable("code", code);
-        context.setVariable("expiresMinutes", expireMinutes);
-        context.setVariable("year", Year.now().getValue());
-
-        return templateEngine.process("email/verification", context);
-    }
-
-    private void sendJoinEmailVerificationEmail(String email, String code) {
-        String html = buildVerificationHtml(email, code);
-        emailClient.sendOneEmail(email, SUBJECT, html);
-    }
-
-    private EmailVerification saveNewEmailVerification(String email, String code, LocalDateTime now) {
-        EmailVerification emailVerification = EmailVerification.builder()
-                .email(email)
-                .purpose(EmailPurpose.SIGNUP)
-                .code(code)
-                .status(EmailVerifyStatus.PENDING)
-                .attemptCount(0)
-                .expiresAt(now.plusMinutes(expireMinutes))
-                .build();
-        return emailVerificationRepository.save(emailVerification);
-    }
-
-    // TODO 동시성 테스트 필요
     @Override
     public EmailVerificationConfirmResponseDto verifyEmailCode(EmailVerificationConfirmRequestDto emailVerificationConfirmRequestDto) {
-        final LocalDateTime now =  LocalDateTime.now();
-
-        EmailVerification emailVerification = emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(emailVerificationConfirmRequestDto.getEmail(), EmailPurpose.SIGNUP)
-                .orElseThrow(() -> new EntityNotFoundException("EmailVerification",  emailVerificationConfirmRequestDto.getEmail()));
-
-        if (emailVerification.getStatus().equals(EmailVerifyStatus.VERIFIED)) {
-            log.info("이메일이 이미 인증되었습니다. {}", emailVerificationConfirmRequestDto.getEmail());
-            return EmailVerificationConfirmResponseDto.from(emailVerification);
-        }
-
-        if (emailVerification.getStatus() == EmailVerifyStatus.LOCKED) {
-            LocalDateTime lockUntil = emailVerification.getLockedUntil();
-
-            if (lockUntil != null && now.isBefore(lockUntil)) {
-                throw new EmailVerificationLockedException();
-            }
-
-            emailVerification.updateStatus(EmailVerifyStatus.PENDING);
-            emailVerification.resetAttemptCount();
-        }
-
-        if (emailVerification.getExpiresAt().isBefore(now)) {
-            emailVerification.updateStatus(EmailVerifyStatus.EXPIRED);
-            emailVerificationRepository.save(emailVerification);
-            throw new EmailVerificationExpiredException();
-        }
-
-        if (emailVerification.getCode().equals(emailVerificationConfirmRequestDto.getCode())) {
-            emailVerification.updateStatus(EmailVerifyStatus.VERIFIED);
-            emailVerificationRepository.save(emailVerification);
-            return EmailVerificationConfirmResponseDto.from(emailVerification);
-        }
-
-        emailVerification.increaseAttemptCount();
-
-        if (emailVerification.getAttemptCount() >= maxAttempts) {
-            emailVerification.updateStatus(EmailVerifyStatus.LOCKED);
-            emailVerification.updateLockedUntil(LocalDateTime.now().plusMinutes(lockMinutes));
-            emailVerificationRepository.save(emailVerification);
-
-            throw new EmailVerificationAttemptLimitExceededException();
-        }
-
-        emailVerificationRepository.save(emailVerification);
-
-        return EmailVerificationConfirmResponseDto.from(emailVerification);
+        return emailVerificationService.verifyCode(
+                emailVerificationConfirmRequestDto.getEmail(),
+                emailVerificationConfirmRequestDto.getCode(),
+                EmailPurpose.SIGNUP
+        );
     }
 }

--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/service/impl/PasswordResetServiceImpl.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/auth/service/impl/PasswordResetServiceImpl.java
@@ -1,0 +1,87 @@
+package com.leedahun.identityservice.domain.auth.service.impl;
+
+import com.leedahun.identityservice.common.error.exception.EntityNotFoundException;
+import com.leedahun.identityservice.domain.auth.dto.EmailVerificationConfirmResponseDto;
+import com.leedahun.identityservice.domain.auth.dto.PasswordResetConfirmRequestDto;
+import com.leedahun.identityservice.domain.auth.dto.PasswordResetRequestDto;
+import com.leedahun.identityservice.domain.auth.dto.PasswordResetVerifyRequestDto;
+import com.leedahun.identityservice.domain.auth.entity.EmailPurpose;
+import com.leedahun.identityservice.domain.auth.entity.User;
+import com.leedahun.identityservice.domain.auth.exception.EmailVerificationRequiredException;
+import com.leedahun.identityservice.domain.auth.exception.PasswordMismatchException;
+import com.leedahun.identityservice.domain.auth.exception.SamePasswordException;
+import com.leedahun.identityservice.domain.auth.repository.UserRepository;
+import com.leedahun.identityservice.domain.auth.service.EmailVerificationService;
+import com.leedahun.identityservice.domain.auth.service.PasswordResetService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PasswordResetServiceImpl implements PasswordResetService {
+
+    private static final String PASSWORD_RESET_EMAIL_SUBJECT = "[Key Feed] 비밀번호 재설정을 위한 인증번호입니다.";
+
+    private final UserRepository userRepository;
+    private final EmailVerificationService emailVerificationService;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    @Override
+    public void requestPasswordReset(PasswordResetRequestDto requestDto) {
+        String email = requestDto.getEmail();
+
+        // 등록된 사용자인지 확인
+        userRepository.findByEmail(email)
+                .orElseThrow(() -> new EntityNotFoundException("User", email));
+
+        emailVerificationService.sendVerificationEmail(email, EmailPurpose.RESET, PASSWORD_RESET_EMAIL_SUBJECT);
+    }
+
+    @Override
+    public EmailVerificationConfirmResponseDto verifyCode(PasswordResetVerifyRequestDto requestDto) {
+        return emailVerificationService.verifyCode(
+                requestDto.getEmail(),
+                requestDto.getCode(),
+                EmailPurpose.RESET
+        );
+    }
+
+    @Override
+    public void resetPassword(PasswordResetConfirmRequestDto requestDto) {
+        String email = requestDto.getEmail();
+        String newPassword = requestDto.getNewPassword();
+        String confirmPassword = requestDto.getConfirmPassword();
+
+        // 비밀번호 일치 확인
+        if (!newPassword.equals(confirmPassword)) {
+            throw new PasswordMismatchException();
+        }
+
+        // 이메일 인증 완료 여부 확인
+        if (!emailVerificationService.isVerified(email, EmailPurpose.RESET)) {
+            throw new EmailVerificationRequiredException();
+        }
+
+        // 사용자 조회
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new EntityNotFoundException("User", email));
+
+        // 기존 비밀번호와 동일한지 확인
+        if (passwordEncoder.matches(newPassword, user.getPassword())) {
+            throw new SamePasswordException();
+        }
+
+        user.updatePassword(passwordEncoder.encode(newPassword));
+        userRepository.save(user);
+
+        // 인증 레코드 삭제
+        emailVerificationService.deleteVerification(email, EmailPurpose.RESET);
+
+        log.info("비밀번호 재설정 완료: {}", email);
+    }
+}

--- a/identity-service/src/test/java/com/leedahun/identityservice/domain/auth/controller/AuthControllerTest.java
+++ b/identity-service/src/test/java/com/leedahun/identityservice/domain/auth/controller/AuthControllerTest.java
@@ -30,6 +30,7 @@ import com.leedahun.identityservice.domain.auth.entity.Role;
 import com.leedahun.identityservice.domain.auth.exception.RefreshTokenNotExistsException;
 import com.leedahun.identityservice.domain.auth.service.JoinService;
 import com.leedahun.identityservice.domain.auth.service.LoginService;
+import com.leedahun.identityservice.domain.auth.service.PasswordResetService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -62,6 +63,9 @@ class AuthControllerTest {
 
     @MockitoBean
     JoinService joinService;
+
+    @MockitoBean
+    PasswordResetService passwordResetService;
 
     @MockitoBean
     JwtProperties jwtProperties;

--- a/identity-service/src/test/java/com/leedahun/identityservice/domain/auth/service/impl/EmailVerificationServiceImplTest.java
+++ b/identity-service/src/test/java/com/leedahun/identityservice/domain/auth/service/impl/EmailVerificationServiceImplTest.java
@@ -1,0 +1,416 @@
+package com.leedahun.identityservice.domain.auth.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.leedahun.identityservice.common.error.exception.EntityNotFoundException;
+import com.leedahun.identityservice.common.mail.EmailClient;
+import com.leedahun.identityservice.domain.auth.dto.EmailVerificationConfirmResponseDto;
+import com.leedahun.identityservice.domain.auth.entity.EmailPurpose;
+import com.leedahun.identityservice.domain.auth.entity.EmailVerification;
+import com.leedahun.identityservice.domain.auth.entity.EmailVerifyStatus;
+import com.leedahun.identityservice.domain.auth.exception.EmailVerificationAlreadyDoneException;
+import com.leedahun.identityservice.domain.auth.exception.EmailVerificationAttemptLimitExceededException;
+import com.leedahun.identityservice.domain.auth.exception.EmailVerificationExpiredException;
+import com.leedahun.identityservice.domain.auth.exception.EmailVerificationLockedException;
+import com.leedahun.identityservice.domain.auth.repository.EmailVerificationRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+@ExtendWith(MockitoExtension.class)
+class EmailVerificationServiceImplTest {
+
+    @Mock
+    private EmailVerificationRepository emailVerificationRepository;
+
+    @Mock
+    private SpringTemplateEngine templateEngine;
+
+    @Mock
+    private EmailClient emailClient;
+
+    @InjectMocks
+    private EmailVerificationServiceImpl emailVerificationService;
+
+    private static final String EMAIL = "user@test.com";
+    private static final String CODE = "123456";
+    private static final String SUBJECT = "[Key Feed] 테스트 이메일";
+    private static final String HTML = "<html>EMAIL</html>";
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(emailVerificationService, "maxAttempts", 5);
+        ReflectionTestUtils.setField(emailVerificationService, "expireMinutes", 10);
+        ReflectionTestUtils.setField(emailVerificationService, "lockMinutes", 3);
+    }
+
+    @Nested
+    @DisplayName("이메일 인증 발송 테스트")
+    class SendVerificationEmailTests {
+
+        @Test
+        @DisplayName("이전 인증 기록이 없으면 새 인증을 저장하고 메일을 전송한다")
+        void sendVerificationEmail_firstTime_success() {
+            // given
+            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(EMAIL, EmailPurpose.SIGNUP))
+                    .willReturn(Optional.empty());
+            given(templateEngine.process(anyString(), any(Context.class))).willReturn(HTML);
+
+            // when
+            emailVerificationService.sendVerificationEmail(EMAIL, EmailPurpose.SIGNUP, SUBJECT);
+
+            // then
+            then(emailVerificationRepository).should().save(any(EmailVerification.class));
+            then(emailClient).should().sendOneEmail(eq(EMAIL), eq(SUBJECT), eq(HTML));
+        }
+
+        @Test
+        @DisplayName("이미 인증된 경우 예외를 발생한다")
+        void sendVerificationEmail_alreadyVerified_throws() {
+            // given
+            EmailVerification emailVerification = EmailVerification.builder()
+                    .email(EMAIL)
+                    .purpose(EmailPurpose.SIGNUP)
+                    .status(EmailVerifyStatus.VERIFIED)
+                    .build();
+            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(EMAIL, EmailPurpose.SIGNUP))
+                    .willReturn(Optional.of(emailVerification));
+
+            // when & then
+            assertThatThrownBy(() -> emailVerificationService.sendVerificationEmail(EMAIL, EmailPurpose.SIGNUP, SUBJECT))
+                    .isInstanceOf(EmailVerificationAlreadyDoneException.class);
+
+            then(emailClient).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("잠금 상태이고 잠금 기간이 만료되지 않은 경우 예외가 발생한다")
+        void sendVerificationEmail_lockedAndStillLocked_throws() {
+            // given
+            EmailVerification emailVerification = EmailVerification.builder()
+                    .email(EMAIL)
+                    .purpose(EmailPurpose.SIGNUP)
+                    .status(EmailVerifyStatus.LOCKED)
+                    .lockedUntil(LocalDateTime.now().plusMinutes(5))
+                    .build();
+            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(EMAIL, EmailPurpose.SIGNUP))
+                    .willReturn(Optional.of(emailVerification));
+
+            // when & then
+            assertThatThrownBy(() -> emailVerificationService.sendVerificationEmail(EMAIL, EmailPurpose.SIGNUP, SUBJECT))
+                    .isInstanceOf(EmailVerificationLockedException.class);
+
+            then(emailClient).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("잠금 기간이 만료된 경우 초기화 후 재발송한다")
+        void sendVerificationEmail_lockedButExpired_thenResetAndSend() {
+            // given
+            EmailVerification emailVerification = EmailVerification.builder()
+                    .email(EMAIL)
+                    .purpose(EmailPurpose.SIGNUP)
+                    .status(EmailVerifyStatus.LOCKED)
+                    .lockedUntil(LocalDateTime.now().minusMinutes(1))
+                    .expiresAt(LocalDateTime.now().minusMinutes(1))
+                    .build();
+            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(EMAIL, EmailPurpose.SIGNUP))
+                    .willReturn(Optional.of(emailVerification));
+            given(templateEngine.process(anyString(), any(Context.class))).willReturn(HTML);
+
+            // when
+            emailVerificationService.sendVerificationEmail(EMAIL, EmailPurpose.SIGNUP, SUBJECT);
+
+            // then
+            verify(emailVerificationRepository, times(1)).save(any(EmailVerification.class));
+            then(emailClient).should().sendOneEmail(eq(EMAIL), eq(SUBJECT), eq(HTML));
+        }
+
+        @Test
+        @DisplayName("대기 상태이고 아직 유효한 경우 코드 갱신 후 재발송한다")
+        void sendVerificationEmail_pendingAndValid_thenUpdateAndSend() {
+            // given
+            EmailVerification emailVerification = EmailVerification.builder()
+                    .email(EMAIL)
+                    .purpose(EmailPurpose.SIGNUP)
+                    .status(EmailVerifyStatus.PENDING)
+                    .expiresAt(LocalDateTime.now().plusMinutes(10))
+                    .build();
+            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(EMAIL, EmailPurpose.SIGNUP))
+                    .willReturn(Optional.of(emailVerification));
+            given(templateEngine.process(anyString(), any(Context.class))).willReturn(HTML);
+
+            // when
+            emailVerificationService.sendVerificationEmail(EMAIL, EmailPurpose.SIGNUP, SUBJECT);
+
+            // then
+            then(emailVerificationRepository).should().save(any(EmailVerification.class));
+            then(emailClient).should().sendOneEmail(eq(EMAIL), eq(SUBJECT), eq(HTML));
+        }
+    }
+
+    @Nested
+    @DisplayName("인증 코드 검증 테스트")
+    class VerifyCodeTests {
+
+        @Test
+        @DisplayName("이미 인증 완료 상태인 경우 바로 응답한다")
+        void verifyCode_alreadyVerified_returns() {
+            // given
+            EmailVerification emailVerification = EmailVerification.builder()
+                    .email(EMAIL)
+                    .purpose(EmailPurpose.SIGNUP)
+                    .status(EmailVerifyStatus.VERIFIED)
+                    .build();
+            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(EMAIL, EmailPurpose.SIGNUP))
+                    .willReturn(Optional.of(emailVerification));
+
+            // when
+            EmailVerificationConfirmResponseDto result = emailVerificationService.verifyCode(EMAIL, CODE, EmailPurpose.SIGNUP);
+
+            // then
+            assertThat(result.getStatus()).isEqualTo(EmailVerifyStatus.VERIFIED);
+            then(emailVerificationRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("잠금 상태 유지 시간이 남았을 경우 예외가 발생한다")
+        void verifyCode_lockedStill_throws() {
+            // given
+            EmailVerification emailVerification = EmailVerification.builder()
+                    .email(EMAIL)
+                    .purpose(EmailPurpose.SIGNUP)
+                    .status(EmailVerifyStatus.LOCKED)
+                    .lockedUntil(LocalDateTime.now().plusMinutes(3))
+                    .build();
+            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(EMAIL, EmailPurpose.SIGNUP))
+                    .willReturn(Optional.of(emailVerification));
+
+            // when & then
+            assertThatThrownBy(() -> emailVerificationService.verifyCode(EMAIL, CODE, EmailPurpose.SIGNUP))
+                    .isInstanceOf(EmailVerificationLockedException.class);
+
+            then(emailVerificationRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("인증 가능 시간이 만료되었을 경우 만료 상태로 저장 후 예외를 발생한다")
+        void verifyCode_expired_throwsAndSaveExpired() {
+            // given
+            EmailVerification emailVerification = EmailVerification.builder()
+                    .email(EMAIL)
+                    .purpose(EmailPurpose.SIGNUP)
+                    .status(EmailVerifyStatus.PENDING)
+                    .expiresAt(LocalDateTime.now().minusSeconds(1))
+                    .build();
+            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(EMAIL, EmailPurpose.SIGNUP))
+                    .willReturn(Optional.of(emailVerification));
+
+            // when & then
+            assertThatThrownBy(() -> emailVerificationService.verifyCode(EMAIL, CODE, EmailPurpose.SIGNUP))
+                    .isInstanceOf(EmailVerificationExpiredException.class);
+
+            ArgumentCaptor<EmailVerification> captor = ArgumentCaptor.forClass(EmailVerification.class);
+            then(emailVerificationRepository).should().save(captor.capture());
+            assertThat(captor.getValue().getStatus()).isEqualTo(EmailVerifyStatus.EXPIRED);
+        }
+
+        @Test
+        @DisplayName("코드가 일치할 경우 인증 완료 상태로 저장한다")
+        void verifyCode_codeMatches_success() {
+            // given
+            EmailVerification emailVerification = EmailVerification.builder()
+                    .email(EMAIL)
+                    .purpose(EmailPurpose.SIGNUP)
+                    .status(EmailVerifyStatus.PENDING)
+                    .expiresAt(LocalDateTime.now().plusMinutes(5))
+                    .code(CODE)
+                    .build();
+            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(EMAIL, EmailPurpose.SIGNUP))
+                    .willReturn(Optional.of(emailVerification));
+
+            // when
+            EmailVerificationConfirmResponseDto result = emailVerificationService.verifyCode(EMAIL, CODE, EmailPurpose.SIGNUP);
+
+            // then
+            assertThat(result.getStatus()).isEqualTo(EmailVerifyStatus.VERIFIED);
+            ArgumentCaptor<EmailVerification> captor = ArgumentCaptor.forClass(EmailVerification.class);
+            then(emailVerificationRepository).should().save(captor.capture());
+            assertThat(captor.getValue().getStatus()).isEqualTo(EmailVerifyStatus.VERIFIED);
+        }
+
+        @Test
+        @DisplayName("코드가 불일치하고 시도 횟수가 남았을 경우 시도 횟수를 증가시킨다")
+        void verifyCode_codeNotMatch_underMax_increasesCount() {
+            // given
+            EmailVerification emailVerification = EmailVerification.builder()
+                    .email(EMAIL)
+                    .purpose(EmailPurpose.SIGNUP)
+                    .status(EmailVerifyStatus.PENDING)
+                    .expiresAt(LocalDateTime.now().plusMinutes(5))
+                    .code(CODE)
+                    .attemptCount(1)
+                    .build();
+            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(EMAIL, EmailPurpose.SIGNUP))
+                    .willReturn(Optional.of(emailVerification));
+
+            // when
+            EmailVerificationConfirmResponseDto result = emailVerificationService.verifyCode(EMAIL, "wrong_code", EmailPurpose.SIGNUP);
+
+            // then
+            assertThat(result.getStatus()).isEqualTo(EmailVerifyStatus.PENDING);
+            then(emailVerificationRepository).should().save(any(EmailVerification.class));
+        }
+
+        @Test
+        @DisplayName("코드가 불일치하고 시도 횟수가 한계에 도달한 경우 잠금 상태로 저장한다")
+        void verifyCode_codeNotMatch_reachMax_thenLockedAndThrows() {
+            // given
+            EmailVerification emailVerification = EmailVerification.builder()
+                    .email(EMAIL)
+                    .purpose(EmailPurpose.SIGNUP)
+                    .status(EmailVerifyStatus.PENDING)
+                    .expiresAt(LocalDateTime.now().plusMinutes(5))
+                    .code(CODE)
+                    .attemptCount(4)
+                    .build();
+            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(EMAIL, EmailPurpose.SIGNUP))
+                    .willReturn(Optional.of(emailVerification));
+
+            // when & then
+            assertThatThrownBy(() -> emailVerificationService.verifyCode(EMAIL, "wrong_code", EmailPurpose.SIGNUP))
+                    .isInstanceOf(EmailVerificationAttemptLimitExceededException.class);
+
+            ArgumentCaptor<EmailVerification> captor = ArgumentCaptor.forClass(EmailVerification.class);
+            then(emailVerificationRepository).should().save(captor.capture());
+            assertThat(captor.getValue().getStatus()).isEqualTo(EmailVerifyStatus.LOCKED);
+            assertThat(captor.getValue().getLockedUntil()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("기록이 없을 경우 예외가 발생한다")
+        void verifyCode_noRecord_throws() {
+            // given
+            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(EMAIL, EmailPurpose.SIGNUP))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> emailVerificationService.verifyCode(EMAIL, CODE, EmailPurpose.SIGNUP))
+                    .isInstanceOf(EntityNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("인증 완료 여부 확인 테스트")
+    class IsVerifiedTests {
+
+        @Test
+        @DisplayName("인증 완료 상태이면 true를 반환한다")
+        void isVerified_verified_returnsTrue() {
+            // given
+            EmailVerification emailVerification = EmailVerification.builder()
+                    .email(EMAIL)
+                    .purpose(EmailPurpose.RESET)
+                    .status(EmailVerifyStatus.VERIFIED)
+                    .build();
+            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(EMAIL, EmailPurpose.RESET))
+                    .willReturn(Optional.of(emailVerification));
+
+            // when
+            boolean result = emailVerificationService.isVerified(EMAIL, EmailPurpose.RESET);
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("인증 미완료 상태이면 false를 반환한다")
+        void isVerified_notVerified_returnsFalse() {
+            // given
+            EmailVerification emailVerification = EmailVerification.builder()
+                    .email(EMAIL)
+                    .purpose(EmailPurpose.RESET)
+                    .status(EmailVerifyStatus.PENDING)
+                    .build();
+            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(EMAIL, EmailPurpose.RESET))
+                    .willReturn(Optional.of(emailVerification));
+
+            // when
+            boolean result = emailVerificationService.isVerified(EMAIL, EmailPurpose.RESET);
+
+            // then
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        @DisplayName("기록이 없으면 false를 반환한다")
+        void isVerified_noRecord_returnsFalse() {
+            // given
+            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(EMAIL, EmailPurpose.RESET))
+                    .willReturn(Optional.empty());
+
+            // when
+            boolean result = emailVerificationService.isVerified(EMAIL, EmailPurpose.RESET);
+
+            // then
+            assertThat(result).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("인증 레코드 삭제 테스트")
+    class DeleteVerificationTests {
+
+        @Test
+        @DisplayName("인증 레코드가 있으면 삭제한다")
+        void deleteVerification_exists_deletes() {
+            // given
+            EmailVerification emailVerification = EmailVerification.builder()
+                    .email(EMAIL)
+                    .purpose(EmailPurpose.RESET)
+                    .build();
+            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(EMAIL, EmailPurpose.RESET))
+                    .willReturn(Optional.of(emailVerification));
+
+            // when
+            emailVerificationService.deleteVerification(EMAIL, EmailPurpose.RESET);
+
+            // then
+            then(emailVerificationRepository).should().delete(emailVerification);
+        }
+
+        @Test
+        @DisplayName("인증 레코드가 없으면 아무것도 하지 않는다")
+        void deleteVerification_notExists_doesNothing() {
+            // given
+            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(EMAIL, EmailPurpose.RESET))
+                    .willReturn(Optional.empty());
+
+            // when
+            emailVerificationService.deleteVerification(EMAIL, EmailPurpose.RESET);
+
+            // then
+            then(emailVerificationRepository).should(never()).delete(any());
+        }
+    }
+}

--- a/identity-service/src/test/java/com/leedahun/identityservice/domain/auth/service/impl/JoinServiceTest.java
+++ b/identity-service/src/test/java/com/leedahun/identityservice/domain/auth/service/impl/JoinServiceTest.java
@@ -4,8 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -13,25 +11,16 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.leedahun.identityservice.common.error.exception.EntityNotFoundException;
-import com.leedahun.identityservice.common.mail.EmailClient;
 import com.leedahun.identityservice.domain.auth.dto.EmailVerificationConfirmRequestDto;
 import com.leedahun.identityservice.domain.auth.dto.EmailVerificationConfirmResponseDto;
 import com.leedahun.identityservice.domain.auth.dto.JoinRequestDto;
 import com.leedahun.identityservice.domain.auth.entity.EmailPurpose;
-import com.leedahun.identityservice.domain.auth.entity.EmailVerification;
 import com.leedahun.identityservice.domain.auth.entity.EmailVerifyStatus;
 import com.leedahun.identityservice.domain.auth.entity.User;
-import com.leedahun.identityservice.domain.auth.exception.EmailVerificationAlreadyDoneException;
-import com.leedahun.identityservice.domain.auth.exception.EmailVerificationAttemptLimitExceededException;
-import com.leedahun.identityservice.domain.auth.exception.EmailVerificationExpiredException;
-import com.leedahun.identityservice.domain.auth.exception.EmailVerificationLockedException;
 import com.leedahun.identityservice.domain.auth.exception.UserAlreadyExistsException;
-import com.leedahun.identityservice.domain.auth.repository.EmailVerificationRepository;
 import com.leedahun.identityservice.domain.auth.repository.UserRepository;
-import java.time.LocalDateTime;
+import com.leedahun.identityservice.domain.auth.service.EmailVerificationService;
 import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -41,9 +30,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.test.util.ReflectionTestUtils;
-import org.thymeleaf.context.Context;
-import org.thymeleaf.spring6.SpringTemplateEngine;
 
 @ExtendWith(MockitoExtension.class)
 class JoinServiceTest {
@@ -52,39 +38,23 @@ class JoinServiceTest {
     private UserRepository userRepository;
 
     @Mock
-    private EmailVerificationRepository emailVerificationRepository;
+    private BCryptPasswordEncoder passwordEncoder;
 
     @Mock
-    BCryptPasswordEncoder passwordEncoder;
-
-    @Mock
-    private SpringTemplateEngine templateEngine;
-
-    @Mock
-    private EmailClient emailClient;
+    private EmailVerificationService emailVerificationService;
 
     @InjectMocks
     private JoinServiceImpl joinService;
 
     private static final String EMAIL = "user@test.com";
     private static final String NAME = "tester";
-    private static final String PHONE = "010-1234-5678";
     private static final String RAW_PW = "plainPW!";
     private static final String ENC_PW = "$2a$10$encoded";
-
     private static final String EMAIL_CODE = "123456";
-    private static final String HTML = "<html>EMAIL</html>";
-
-    @BeforeEach
-    void setUp() {
-        ReflectionTestUtils.setField(joinService, "maxAttempts", 5);
-        ReflectionTestUtils.setField(joinService, "expireMinutes", 10);
-        ReflectionTestUtils.setField(joinService, "lockMinutes", 3);
-    }
 
     @Nested
     @DisplayName("회원가입 테스트")
-    class joinTests {
+    class JoinTests {
 
         @Test
         @DisplayName("신규 이메일이면 사용자를 저장하고 비밀번호를 암호화한다")
@@ -127,310 +97,51 @@ class JoinServiceTest {
 
             verify(userRepository, never()).save(any(User.class));
         }
-
     }
 
     @Nested
     @DisplayName("회원가입 이메일 전송 요청 테스트")
     class SendJoinEmailTests {
 
-        final String BRAND_NAME = "Key Feed";
-
         @Test
-        @DisplayName("회원가입 이메일 요청 시 이전 인증 기록 없을 경우 새 인증을 저장하고 메일을 전송한다")
-        void send_firstTime_success() {
-            // given
-            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(anyString(), eq(EmailPurpose.SIGNUP)))
-                    .willReturn(Optional.empty());
-            given(templateEngine.process(anyString(), any(Context.class))).willReturn(HTML);
-
+        @DisplayName("회원가입 이메일 요청 시 EmailVerificationService를 호출한다")
+        void sendJoinEmail_delegatesToEmailVerificationService() {
             // when
             joinService.sendJoinEmail(EMAIL);
 
             // then
-            then(emailVerificationRepository).should().save(any(EmailVerification.class));
-            then(emailClient).should().sendOneEmail(eq(EMAIL), contains(BRAND_NAME), eq(HTML));
-            verify(emailClient, times(1)).sendOneEmail(eq(EMAIL), contains(BRAND_NAME), eq(HTML));
-        }
-
-        @Test
-        @DisplayName("회원가입 이메일 요청 시 이미 인증된 경우 예외를 발생한다")
-        void send_alreadyVerified_throws() {
-            // given
-            EmailVerification emailVerification = EmailVerification.builder()
-                    .email(EMAIL)
-                    .purpose(EmailPurpose.SIGNUP)
-                    .status(EmailVerifyStatus.VERIFIED)  // 이미 인증완료 상태인 경우
-                    .build();
-            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(anyString(), eq(EmailPurpose.SIGNUP)))
-                    .willReturn(Optional.of(emailVerification));
-
-            // when & then
-            assertThatThrownBy(() -> joinService.sendJoinEmail(EMAIL))
-                    .isInstanceOf(EmailVerificationAlreadyDoneException.class);
-
-            then(emailClient).shouldHaveNoInteractions();
-        }
-
-        @Test
-        @DisplayName("회원가입 이메일 요청 시 잠금 상태이고 잠금기간이 만료되지 않은 경우 예외가 발생한다")
-        void send_lockedAndStillLocked_throws() {
-            // given
-            EmailVerification emailVerification = EmailVerification.builder()
-                    .email(EMAIL)
-                    .purpose(EmailPurpose.SIGNUP)
-                    .status(EmailVerifyStatus.LOCKED)  // 이미 잠금상태인 경우
-                    .lockedUntil(LocalDateTime.now().plusMinutes(5))  // 잠금기간이 만료되지 않은 경우
-                    .build();
-            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(anyString(), eq(EmailPurpose.SIGNUP)))
-                    .willReturn(Optional.of(emailVerification));
-
-            // when & then
-            assertThatThrownBy(() -> joinService.sendJoinEmail(EMAIL))
-                    .isInstanceOf(EmailVerificationLockedException.class);
-
-            then(emailClient).shouldHaveNoInteractions();
-        }
-
-        @Test
-        @DisplayName("회원가입 이메일 요청 시 잠금 기간이 만료된 경우 초기화 후 재발송한다")
-        void send_lockedButExpired_thenResetAndSend() {
-            // given
-            EmailVerification emailVerification = EmailVerification.builder()
-                    .email(EMAIL)
-                    .purpose(EmailPurpose.SIGNUP)
-                    .status(EmailVerifyStatus.LOCKED)
-                    .lockedUntil(LocalDateTime.now().minusMinutes(1))  // 잠금기간이 만료된 경우
-                    .expiresAt(LocalDateTime.now().minusMinutes(1))
-                    .build();
-            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(anyString(), eq(EmailPurpose.SIGNUP)))
-                    .willReturn(Optional.of(emailVerification));
-            given(templateEngine.process(eq("email/verification"), any(Context.class))).willReturn(HTML);
-
-            // when
-            joinService.sendJoinEmail(EMAIL);
-
-            // then
-            verify(emailVerificationRepository, times(1)).save(any(EmailVerification.class));
-            then(emailClient).should().sendOneEmail(eq(EMAIL), contains(BRAND_NAME), eq(HTML));
-        }
-
-        @Test
-        @DisplayName("회원가입 이메일 요청 시 요청상태이고 아직 유효한 경우 코드 갱신 및 기간연장 후 재발송한다")
-        void send_pendingAndValid_thenUpdateAndSend() {
-            // given
-            EmailVerification emailVerification = EmailVerification.builder()
-                    .email(EMAIL)
-                    .purpose(EmailPurpose.SIGNUP)
-                    .status(EmailVerifyStatus.PENDING)  // 요청 상태인 경우
-                    .expiresAt(LocalDateTime.now().plusMinutes(10))  // 아직 유효한 경우
-                    .build();
-            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(anyString(), eq(EmailPurpose.SIGNUP)))
-                    .willReturn(Optional.of(emailVerification));
-            given(templateEngine.process(eq("email/verification"), any(Context.class))).willReturn(HTML);
-
-            // when
-            joinService.sendJoinEmail(EMAIL);
-
-            // then
-            then(emailVerificationRepository).should().save(any(EmailVerification.class));
-            then(emailClient).should().sendOneEmail(eq(EMAIL), contains(BRAND_NAME), eq(HTML));
-            verify(emailVerificationRepository, times(1)).save(any(EmailVerification.class));
-            verify(emailClient, times(1)).sendOneEmail(eq(EMAIL), contains(BRAND_NAME), eq(HTML));
-        }
-
-        @Test
-        @DisplayName("회원가입 이메일 요청 시 요청상태이고 만료된 경우 기존 이력을 리셋하고 새 이력을 저장한다")
-        void sendJoinEmail_existing_expired_marksExpired_thenCreatesNew_andSends() {
-            // given
-            LocalDateTime now = LocalDateTime.now();
-            EmailVerification emailVerification = EmailVerification.builder()
-                    .email(EMAIL)
-                    .purpose(EmailPurpose.SIGNUP)
-                    .status(EmailVerifyStatus.PENDING)
-                    .expiresAt(now.minusSeconds(1))
-                    .build();
-
-            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(EMAIL, EmailPurpose.SIGNUP))
-                    .willReturn(Optional.of(emailVerification));
-
-            // when
-            joinService.sendJoinEmail(EMAIL);
-
-            // then
-            then(emailVerificationRepository).should().save(
-                argThat(saved -> saved == emailVerification && saved.getStatus() == EmailVerifyStatus.EXPIRED)
+            then(emailVerificationService).should().sendVerificationEmail(
+                    eq(EMAIL),
+                    eq(EmailPurpose.SIGNUP),
+                    anyString()
             );
-
-            then(emailVerificationRepository).should().save(argThat(saved ->
-                    saved != emailVerification
-                            && EMAIL.equals(saved.getEmail())
-                            && saved.getStatus() == EmailVerifyStatus.PENDING
-            ));
-
-            then(emailClient).should(times(1)).sendOneEmail(eq(EMAIL), contains(BRAND_NAME), eq(null));
-            then(emailVerificationRepository).shouldHaveNoMoreInteractions();
         }
-
     }
 
     @Nested
+    @DisplayName("회원가입 이메일 코드 검증 테스트")
     class VerifyEmailCodeTests {
 
         @Test
-        @DisplayName("회원가입 인증코드 인증 시 이미 인증완료상태인 경우 바로 응답한다")
-        void verify_alreadyVerified_returns() {
+        @DisplayName("코드 검증 시 EmailVerificationService를 호출한다")
+        void verifyEmailCode_delegatesToEmailVerificationService() {
             // given
-            EmailVerification emailVerification = EmailVerification.builder()
+            EmailVerificationConfirmRequestDto requestDto = EmailVerificationConfirmRequestDto.builder()
                     .email(EMAIL)
-                    .purpose(EmailPurpose.SIGNUP)
+                    .code(EMAIL_CODE)
+                    .build();
+            EmailVerificationConfirmResponseDto expectedResponse = EmailVerificationConfirmResponseDto.builder()
                     .status(EmailVerifyStatus.VERIFIED)
-                    .attemptCount(0)
                     .build();
-            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(anyString(), eq(EmailPurpose.SIGNUP)))
-                    .willReturn(Optional.of(emailVerification));
+            given(emailVerificationService.verifyCode(EMAIL, EMAIL_CODE, EmailPurpose.SIGNUP))
+                    .willReturn(expectedResponse);
 
             // when
-            EmailVerificationConfirmResponseDto emailVerificationConfirmResult = joinService.verifyEmailCode(
-                    new EmailVerificationConfirmRequestDto(EMAIL, "ANY")
-            );
+            EmailVerificationConfirmResponseDto result = joinService.verifyEmailCode(requestDto);
 
             // then
-            assertThat(emailVerificationConfirmResult.getStatus()).isEqualTo(EmailVerifyStatus.VERIFIED);
-            then(emailVerificationRepository).should(never()).save(any());
+            assertThat(result.getStatus()).isEqualTo(EmailVerifyStatus.VERIFIED);
+            then(emailVerificationService).should().verifyCode(EMAIL, EMAIL_CODE, EmailPurpose.SIGNUP);
         }
-
-        @Test
-        @DisplayName("회원가입 인증코드 인증 시 잠금상태 유지시간이 남았을 경우 예외가 발생한다")
-        void verify_lockedStill_throws() {
-            // given
-            EmailVerification emailVerification = EmailVerification.builder()
-                    .email(EMAIL)
-                    .purpose(EmailPurpose.SIGNUP)
-                    .status(EmailVerifyStatus.LOCKED)
-                    .lockedUntil(LocalDateTime.now().plusMinutes(3))
-                    .build();
-            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(anyString(), eq(EmailPurpose.SIGNUP)))
-                    .willReturn(Optional.of(emailVerification));
-
-            // when / then
-            assertThatThrownBy(() ->
-                    joinService.verifyEmailCode(new EmailVerificationConfirmRequestDto(EMAIL, EMAIL_CODE)))
-                    .isInstanceOf(EmailVerificationLockedException.class);
-
-            then(emailVerificationRepository).should(never()).save(any());
-        }
-
-        @Test
-        @DisplayName("회원가입 인증코드 인증 시 인증가능시간이 만료되었을 경우 만료상태로 저장 후 예외를 발생한다")
-        void verify_expired_throwsAndSaveExpired() {
-            // given
-            EmailVerification emailVerification = EmailVerification.builder()
-                    .email(EMAIL)
-                    .purpose(EmailPurpose.SIGNUP)
-                    .status(EmailVerifyStatus.PENDING)
-                    .expiresAt(LocalDateTime.now().minusSeconds(1))  // 인증시간 만료된 경우
-                    .build();
-            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(anyString(), eq(EmailPurpose.SIGNUP)))
-                    .willReturn(Optional.of(emailVerification));
-
-            // when & then
-            assertThatThrownBy(() ->
-                    joinService.verifyEmailCode(new EmailVerificationConfirmRequestDto(EMAIL, EMAIL_CODE)))
-                    .isInstanceOf(EmailVerificationExpiredException.class);
-
-            ArgumentCaptor<EmailVerification> emailVerificationArgumentCaptor = ArgumentCaptor.forClass(EmailVerification.class);
-            then(emailVerificationRepository).should().save(emailVerificationArgumentCaptor.capture());
-            assertThat(emailVerificationArgumentCaptor.getValue().getStatus()).isEqualTo(EmailVerifyStatus.EXPIRED);
-        }
-
-        @Test
-        @DisplayName("회원가입 인증코드 인증 시 코드가 일치할 경우 인증완료 상태로 저장한다")
-        void verify_codeMatches_success() {
-            // given
-            EmailVerification emailVerification = EmailVerification.builder()
-                    .email(EMAIL)
-                    .purpose(EmailPurpose.SIGNUP)
-                    .status(EmailVerifyStatus.PENDING)
-                    .expiresAt(LocalDateTime.now().plusMinutes(5))
-                    .code(EMAIL_CODE)
-                    .build();
-            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(anyString(), eq(EmailPurpose.SIGNUP)))
-                    .willReturn(Optional.of(emailVerification));
-
-            // when
-            EmailVerificationConfirmResponseDto emailVerificationConfirmResult = joinService.verifyEmailCode(
-                    new EmailVerificationConfirmRequestDto(EMAIL, EMAIL_CODE));
-
-            // then
-            assertThat(emailVerificationConfirmResult.getStatus()).isEqualTo(EmailVerifyStatus.VERIFIED);
-            ArgumentCaptor<EmailVerification> capturedEmailVerification = ArgumentCaptor.forClass(EmailVerification.class);
-            then(emailVerificationRepository).should().save(capturedEmailVerification.capture());
-            assertThat(capturedEmailVerification.getValue().getStatus()).isEqualTo(EmailVerifyStatus.VERIFIED);
-        }
-
-        @Test
-        @DisplayName("회원가입 이메일 코드 인증 시 코드가 불일치하고 시도횟수가 남았을 경우 시도횟수를 증가시키고 저장한다")
-        void verify_codeNotMatch_underMax_increasesCount() {
-            // given
-            EmailVerification emailVerification = EmailVerification.builder()
-                    .email(EMAIL)
-                    .purpose(EmailPurpose.SIGNUP)
-                    .status(EmailVerifyStatus.PENDING)
-                    .expiresAt(LocalDateTime.now().plusMinutes(5))
-                    .code(EMAIL_CODE)
-                    .attemptCount(1)  // 시도횟수가 남은 경우
-                    .build();
-            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(anyString(), eq(EmailPurpose.SIGNUP)))
-                    .willReturn(Optional.of(emailVerification));
-
-            // when
-            EmailVerificationConfirmResponseDto emailVerificationConfirmResult = joinService.verifyEmailCode(
-                    new EmailVerificationConfirmRequestDto(EMAIL, "different_code"));
-
-            // then
-            assertThat(emailVerificationConfirmResult.getStatus()).isEqualTo(EmailVerifyStatus.PENDING);
-            then(emailVerificationRepository).should().save(any(EmailVerification.class));
-        }
-
-        @Test
-        @DisplayName("회원가입 이메일 코드 인증 시 코드가 일치하지 않고 시도횟수가 한계에 도달한 경우 잠금상태로 저장한다")
-        void verify_codeNotMatch_reachMax_thenLockedAndThrows() {
-            // given
-            EmailVerification emailVerification = EmailVerification.builder()
-                    .email(EMAIL)
-                    .purpose(EmailPurpose.SIGNUP)
-                    .status(EmailVerifyStatus.PENDING)
-                    .expiresAt(LocalDateTime.now().plusMinutes(5))
-                    .code(EMAIL_CODE)
-                    .attemptCount(4)
-                    .build();
-            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(anyString(), eq(EmailPurpose.SIGNUP)))
-                    .willReturn(Optional.of(emailVerification));
-
-            // when & then
-            assertThatThrownBy(() ->
-                    joinService.verifyEmailCode(new EmailVerificationConfirmRequestDto(EMAIL, "different_code")))
-                    .isInstanceOf(EmailVerificationAttemptLimitExceededException.class);
-
-            ArgumentCaptor<EmailVerification> emailVerificationArgumentCaptor = ArgumentCaptor.forClass(EmailVerification.class);
-            then(emailVerificationRepository).should().save(emailVerificationArgumentCaptor.capture());
-            assertThat(emailVerificationArgumentCaptor.getValue().getStatus()).isEqualTo(EmailVerifyStatus.LOCKED);
-            assertThat(emailVerificationArgumentCaptor.getValue().getLockedUntil()).isNotNull();
-        }
-
-        @Test
-        @DisplayName("회원가입 이메일 코드 인증 시 기록이 없을 경우 예외가 발생한다")
-        void verify_noRecord_throws() {
-            // given
-            given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(anyString(), eq(EmailPurpose.SIGNUP)))
-                    .willReturn(Optional.empty());
-
-            // when / then
-            assertThatThrownBy(() ->
-                    joinService.verifyEmailCode(new EmailVerificationConfirmRequestDto(EMAIL, EMAIL_CODE)))
-                    .isInstanceOf(EntityNotFoundException.class);
-        }
-
     }
 }

--- a/identity-service/src/test/java/com/leedahun/identityservice/domain/auth/service/impl/PasswordResetServiceImplTest.java
+++ b/identity-service/src/test/java/com/leedahun/identityservice/domain/auth/service/impl/PasswordResetServiceImplTest.java
@@ -1,0 +1,243 @@
+package com.leedahun.identityservice.domain.auth.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.leedahun.identityservice.common.error.exception.EntityNotFoundException;
+import com.leedahun.identityservice.domain.auth.dto.EmailVerificationConfirmResponseDto;
+import com.leedahun.identityservice.domain.auth.dto.PasswordResetConfirmRequestDto;
+import com.leedahun.identityservice.domain.auth.dto.PasswordResetRequestDto;
+import com.leedahun.identityservice.domain.auth.dto.PasswordResetVerifyRequestDto;
+import com.leedahun.identityservice.domain.auth.entity.EmailPurpose;
+import com.leedahun.identityservice.domain.auth.entity.EmailVerifyStatus;
+import com.leedahun.identityservice.domain.auth.entity.User;
+import com.leedahun.identityservice.domain.auth.exception.EmailVerificationRequiredException;
+import com.leedahun.identityservice.domain.auth.exception.PasswordMismatchException;
+import com.leedahun.identityservice.domain.auth.exception.SamePasswordException;
+import com.leedahun.identityservice.domain.auth.repository.UserRepository;
+import com.leedahun.identityservice.domain.auth.service.EmailVerificationService;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class PasswordResetServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private EmailVerificationService emailVerificationService;
+
+    @Mock
+    private BCryptPasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private PasswordResetServiceImpl passwordResetService;
+
+    private static final String EMAIL = "user@test.com";
+    private static final String CODE = "123456";
+    private static final String NEW_PASSWORD = "newPassword123!";
+    private static final String ENCODED_PASSWORD = "$2a$10$encoded";
+
+    @Nested
+    @DisplayName("비밀번호 재설정 요청 테스트")
+    class RequestPasswordResetTests {
+
+        @Test
+        @DisplayName("등록된 사용자의 이메일로 요청하면 인증 이메일이 발송된다")
+        void requestPasswordReset_success() {
+            // given
+            PasswordResetRequestDto requestDto = PasswordResetRequestDto.builder()
+                    .email(EMAIL)
+                    .build();
+            given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(new User()));
+
+            // when
+            passwordResetService.requestPasswordReset(requestDto);
+
+            // then
+            then(emailVerificationService).should().sendVerificationEmail(
+                    eq(EMAIL),
+                    eq(EmailPurpose.RESET),
+                    anyString()
+            );
+        }
+
+        @Test
+        @DisplayName("등록되지 않은 이메일로 요청하면 EntityNotFoundException이 발생한다")
+        void requestPasswordReset_userNotFound_throws() {
+            // given
+            PasswordResetRequestDto requestDto = PasswordResetRequestDto.builder()
+                    .email(EMAIL)
+                    .build();
+            given(userRepository.findByEmail(EMAIL)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> passwordResetService.requestPasswordReset(requestDto))
+                    .isInstanceOf(EntityNotFoundException.class);
+
+            then(emailVerificationService).shouldHaveNoInteractions();
+        }
+    }
+
+    @Nested
+    @DisplayName("인증 코드 검증 테스트")
+    class VerifyCodeTests {
+
+        @Test
+        @DisplayName("올바른 인증 코드로 검증하면 성공한다")
+        void verifyCode_success() {
+            // given
+            PasswordResetVerifyRequestDto requestDto = PasswordResetVerifyRequestDto.builder()
+                    .email(EMAIL)
+                    .code(CODE)
+                    .build();
+            EmailVerificationConfirmResponseDto expectedResponse = EmailVerificationConfirmResponseDto.builder()
+                    .status(EmailVerifyStatus.VERIFIED)
+                    .build();
+            given(emailVerificationService.verifyCode(EMAIL, CODE, EmailPurpose.RESET))
+                    .willReturn(expectedResponse);
+
+            // when
+            EmailVerificationConfirmResponseDto result = passwordResetService.verifyCode(requestDto);
+
+            // then
+            assertThat(result.getStatus()).isEqualTo(EmailVerifyStatus.VERIFIED);
+            then(emailVerificationService).should().verifyCode(EMAIL, CODE, EmailPurpose.RESET);
+        }
+    }
+
+    @Nested
+    @DisplayName("비밀번호 재설정 확정 테스트")
+    class ResetPasswordTests {
+
+        @Test
+        @DisplayName("인증 완료 후 비밀번호 재설정에 성공한다")
+        void resetPassword_success() {
+            // given
+            String oldEncodedPassword = "$2a$10$oldEncoded";
+            PasswordResetConfirmRequestDto requestDto = PasswordResetConfirmRequestDto.builder()
+                    .email(EMAIL)
+                    .newPassword(NEW_PASSWORD)
+                    .confirmPassword(NEW_PASSWORD)
+                    .build();
+            User user = User.builder()
+                    .email(EMAIL)
+                    .password(oldEncodedPassword)
+                    .build();
+
+            given(emailVerificationService.isVerified(EMAIL, EmailPurpose.RESET)).willReturn(true);
+            given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(user));
+            given(passwordEncoder.matches(NEW_PASSWORD, oldEncodedPassword)).willReturn(false);
+            given(passwordEncoder.encode(NEW_PASSWORD)).willReturn(ENCODED_PASSWORD);
+
+            // when
+            passwordResetService.resetPassword(requestDto);
+
+            // then
+            ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+            verify(userRepository).save(userCaptor.capture());
+            assertThat(userCaptor.getValue().getPassword()).isEqualTo(ENCODED_PASSWORD);
+            then(emailVerificationService).should().deleteVerification(EMAIL, EmailPurpose.RESET);
+        }
+
+        @Test
+        @DisplayName("비밀번호와 비밀번호 확인이 일치하지 않으면 PasswordMismatchException이 발생한다")
+        void resetPassword_passwordMismatch_throws() {
+            // given
+            PasswordResetConfirmRequestDto requestDto = PasswordResetConfirmRequestDto.builder()
+                    .email(EMAIL)
+                    .newPassword(NEW_PASSWORD)
+                    .confirmPassword("differentPassword")
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> passwordResetService.resetPassword(requestDto))
+                    .isInstanceOf(PasswordMismatchException.class);
+
+            then(userRepository).should(never()).save(any());
+            then(emailVerificationService).should(never()).deleteVerification(anyString(), any());
+        }
+
+        @Test
+        @DisplayName("이메일 인증이 완료되지 않았으면 EmailVerificationRequiredException이 발생한다")
+        void resetPassword_notVerified_throws() {
+            // given
+            PasswordResetConfirmRequestDto requestDto = PasswordResetConfirmRequestDto.builder()
+                    .email(EMAIL)
+                    .newPassword(NEW_PASSWORD)
+                    .confirmPassword(NEW_PASSWORD)
+                    .build();
+            given(emailVerificationService.isVerified(EMAIL, EmailPurpose.RESET)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> passwordResetService.resetPassword(requestDto))
+                    .isInstanceOf(EmailVerificationRequiredException.class);
+
+            then(userRepository).should(never()).save(any());
+            then(emailVerificationService).should(never()).deleteVerification(anyString(), any());
+        }
+
+        @Test
+        @DisplayName("사용자를 찾을 수 없으면 EntityNotFoundException이 발생한다")
+        void resetPassword_userNotFound_throws() {
+            // given
+            PasswordResetConfirmRequestDto requestDto = PasswordResetConfirmRequestDto.builder()
+                    .email(EMAIL)
+                    .newPassword(NEW_PASSWORD)
+                    .confirmPassword(NEW_PASSWORD)
+                    .build();
+            given(emailVerificationService.isVerified(EMAIL, EmailPurpose.RESET)).willReturn(true);
+            given(userRepository.findByEmail(EMAIL)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> passwordResetService.resetPassword(requestDto))
+                    .isInstanceOf(EntityNotFoundException.class);
+
+            then(emailVerificationService).should(never()).deleteVerification(anyString(), any());
+        }
+
+        @Test
+        @DisplayName("새 비밀번호가 기존 비밀번호와 동일하면 SamePasswordException이 발생한다")
+        void resetPassword_samePassword_throws() {
+            // given
+            String oldEncodedPassword = "$2a$10$oldEncoded";
+            PasswordResetConfirmRequestDto requestDto = PasswordResetConfirmRequestDto.builder()
+                    .email(EMAIL)
+                    .newPassword(NEW_PASSWORD)
+                    .confirmPassword(NEW_PASSWORD)
+                    .build();
+            User user = User.builder()
+                    .email(EMAIL)
+                    .password(oldEncodedPassword)
+                    .build();
+
+            given(emailVerificationService.isVerified(EMAIL, EmailPurpose.RESET)).willReturn(true);
+            given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(user));
+            given(passwordEncoder.matches(NEW_PASSWORD, oldEncodedPassword)).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> passwordResetService.resetPassword(requestDto))
+                    .isInstanceOf(SamePasswordException.class);
+
+            then(userRepository).should(never()).save(any());
+            then(emailVerificationService).should(never()).deleteVerification(anyString(), any());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- 비밀번호 재설정 백엔드 API 구현 (요청/인증코드 검증/비밀번호 재설정 3단계)
- 이메일 인증 공통 서비스 분리 및 회원가입 인증 로직 리팩토링
- 비밀번호 재설정 페이지 UI 구현 및 API 연동
- 단위 테스트 및 README API 명세 추가

## Test plan
- [ ] 비밀번호 재설정 요청 시 이메일 발송 확인
- [ ] 인증코드 검증 성공/실패/만료/잠금 케이스 확인
- [ ] 비밀번호 재설정 성공 및 에러 케이스 확인 (불일치, 미인증, 동일 비밀번호)
- [ ] 기존 회원가입 이메일 인증 정상 동작 확인
- [ ] 전체 테스트 통과 확인

Closes #166