### PR TITLE
[FEAT] 트렌딩 키워드 조회 Repository 쿼리 및 Projection 구현

### DIFF
--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/keyword/repository/KeywordRepository.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/keyword/repository/KeywordRepository.java
@@ -5,6 +5,7 @@ import com.leedahun.identityservice.domain.keyword.entity.Keyword;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -30,5 +31,13 @@ public interface KeywordRepository extends JpaRepository<Keyword, Long> {
     @Modifying
     @Query("DELETE FROM Keyword k WHERE k.user.id = :userId")
     void deleteAllByUserId(@Param("userId") Long userId);
+
+    @Query("""
+            SELECT k.name AS name, COUNT(DISTINCT k.user.id) AS userCount
+            FROM Keyword k
+            GROUP BY k.name
+            ORDER BY userCount DESC
+            """)
+    List<TrendingKeywordProjection> findTrendingKeywords(Pageable pageable);
 
 }

--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/keyword/repository/KeywordRepository.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/keyword/repository/KeywordRepository.java
@@ -36,7 +36,7 @@ public interface KeywordRepository extends JpaRepository<Keyword, Long> {
             SELECT k.name AS name, COUNT(DISTINCT k.user.id) AS userCount
             FROM Keyword k
             GROUP BY k.name
-            ORDER BY userCount DESC
+            ORDER BY userCount DESC, k.name ASC
             """)
     List<TrendingKeywordProjection> findTrendingKeywords(Pageable pageable);
 

--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/keyword/repository/TrendingKeywordProjection.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/keyword/repository/TrendingKeywordProjection.java
@@ -1,0 +1,6 @@
+package com.leedahun.identityservice.domain.keyword.repository;
+
+public interface TrendingKeywordProjection {
+    String getName();
+    Long getUserCount();
+}

--- a/identity-service/src/test/java/com/leedahun/identityservice/domain/keyword/repository/KeywordRepositoryTest.java
+++ b/identity-service/src/test/java/com/leedahun/identityservice/domain/keyword/repository/KeywordRepositoryTest.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import com.leedahun.identityservice.domain.source.entity.Source;
 import com.leedahun.identityservice.domain.source.entity.UserSource;
+import org.springframework.data.domain.PageRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -221,6 +222,100 @@ class KeywordRepositoryTest {
         // Then
         assertThat(resultUserIds).hasSize(1);
         assertThat(resultUserIds).containsExactly(user1.getId());
+    }
+
+    @Test
+    @DisplayName("findTrendingKeywords: 사용자 등록 수 기준으로 인기 키워드 조회")
+    void findTrendingKeywords_success() {
+        // Given - user2에게도 "Java" 키워드 추가 (Java: 2명, Spring: 1명, Docker: 1명)
+        User savedUser2 = entityManager.find(User.class, user2.getId());
+        entityManager.persist(Keyword.builder().name("Java").user(savedUser2).build());
+        entityManager.flush();
+        entityManager.clear();
+
+        // When
+        List<TrendingKeywordProjection> result = keywordRepository.findTrendingKeywords(PageRequest.of(0, 10));
+
+        // Then
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).getName()).isEqualTo("Java");
+        assertThat(result.get(0).getUserCount()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("findTrendingKeywords: Pageable로 상위 N개만 조회")
+    void findTrendingKeywords_withPageable() {
+        // Given - user2에게도 "Java" 키워드 추가
+        User savedUser2 = entityManager.find(User.class, user2.getId());
+        entityManager.persist(Keyword.builder().name("Java").user(savedUser2).build());
+        entityManager.flush();
+        entityManager.clear();
+
+        // When - 상위 2개만 조회
+        List<TrendingKeywordProjection> result = keywordRepository.findTrendingKeywords(PageRequest.of(0, 2));
+
+        // Then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getName()).isEqualTo("Java");
+        assertThat(result.get(0).getUserCount()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("findTrendingKeywords: 키워드가 없는 경우 빈 목록 반환")
+    void findTrendingKeywords_empty() {
+        // Given - 모든 키워드 삭제
+        keywordRepository.deleteAll();
+        entityManager.flush();
+        entityManager.clear();
+
+        // When
+        List<TrendingKeywordProjection> result = keywordRepository.findTrendingKeywords(PageRequest.of(0, 10));
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findTrendingKeywords: 동일 사용자의 동일 키워드는 1명으로 카운트")
+    void findTrendingKeywords_distinctUserCount() {
+        // Given - user1이 이미 "Java"를 가지고 있으므로, 또다시 "Java" 추가해도 DISTINCT로 1명만 카운트
+        // 기존: Java(user1), Spring(user1), Docker(user2) -> Java:1, Spring:1, Docker:1
+        // 실제로는 user.id가 이미 unique하므로 동일 유저가 같은 이름을 가질 수 없지만 (비즈니스 로직에서),
+        // DISTINCT 검증을 위해 user2에게 "Spring" 추가 -> Spring:2
+        User savedUser2 = entityManager.find(User.class, user2.getId());
+        entityManager.persist(Keyword.builder().name("Spring").user(savedUser2).build());
+        entityManager.flush();
+        entityManager.clear();
+
+        // When
+        List<TrendingKeywordProjection> result = keywordRepository.findTrendingKeywords(PageRequest.of(0, 10));
+
+        // Then
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).getName()).isEqualTo("Spring");
+        assertThat(result.get(0).getUserCount()).isEqualTo(2L);
+        // Docker와 Java는 각각 1명
+        assertThat(result.get(1).getUserCount()).isEqualTo(1L);
+        assertThat(result.get(2).getUserCount()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("findTrendingKeywords: 여러 사용자가 동일 키워드를 등록한 경우 정확한 카운트")
+    void findTrendingKeywords_multipleUsersWithSameKeyword() {
+        // Given - 3명의 사용자가 모두 "Java" 등록
+        User user3 = entityManager.persist(new User());
+        User savedUser2 = entityManager.find(User.class, user2.getId());
+        entityManager.persist(Keyword.builder().name("Java").user(savedUser2).build());
+        entityManager.persist(Keyword.builder().name("Java").user(user3).build());
+        entityManager.flush();
+        entityManager.clear();
+
+        // When
+        List<TrendingKeywordProjection> result = keywordRepository.findTrendingKeywords(PageRequest.of(0, 10));
+
+        // Then
+        assertThat(result.get(0).getName()).isEqualTo("Java");
+        assertThat(result.get(0).getUserCount()).isEqualTo(3L);
     }
 
 }

--- a/identity-service/src/test/java/com/leedahun/identityservice/domain/keyword/repository/KeywordRepositoryTest.java
+++ b/identity-service/src/test/java/com/leedahun/identityservice/domain/keyword/repository/KeywordRepositoryTest.java
@@ -276,27 +276,23 @@ class KeywordRepositoryTest {
     }
 
     @Test
-    @DisplayName("findTrendingKeywords: 동일 사용자의 동일 키워드는 1명으로 카운트")
+    @DisplayName("findTrendingKeywords: 동일 사용자가 동일 키워드를 중복 등록해도 1명으로 카운트")
     void findTrendingKeywords_distinctUserCount() {
-        // Given - user1이 이미 "Java"를 가지고 있으므로, 또다시 "Java" 추가해도 DISTINCT로 1명만 카운트
-        // 기존: Java(user1), Spring(user1), Docker(user2) -> Java:1, Spring:1, Docker:1
-        // 실제로는 user.id가 이미 unique하므로 동일 유저가 같은 이름을 가질 수 없지만 (비즈니스 로직에서),
-        // DISTINCT 검증을 위해 user2에게 "Spring" 추가 -> Spring:2
-        User savedUser2 = entityManager.find(User.class, user2.getId());
-        entityManager.persist(Keyword.builder().name("Spring").user(savedUser2).build());
+        // Given - user1이 이미 "Java"를 가지고 있는 상태에서 "Java"를 한 번 더 등록
+        // 비즈니스 로직상 중복 등록은 막히지만, DISTINCT 쿼리 자체의 정확성을 검증
+        // 기존: Java(user1), Spring(user1), Docker(user2)
+        // 추가: Java(user1) -> DB에는 Java 2행이지만 DISTINCT user.id로 여전히 1명
+        User savedUser1 = entityManager.find(User.class, user1.getId());
+        entityManager.persist(Keyword.builder().name("Java").user(savedUser1).build());
         entityManager.flush();
         entityManager.clear();
 
         // When
         List<TrendingKeywordProjection> result = keywordRepository.findTrendingKeywords(PageRequest.of(0, 10));
 
-        // Then
+        // Then - Java는 user1이 2행 가지고 있지만 DISTINCT로 1명만 카운트
         assertThat(result).hasSize(3);
-        assertThat(result.get(0).getName()).isEqualTo("Spring");
-        assertThat(result.get(0).getUserCount()).isEqualTo(2L);
-        // Docker와 Java는 각각 1명
-        assertThat(result.get(1).getUserCount()).isEqualTo(1L);
-        assertThat(result.get(2).getUserCount()).isEqualTo(1L);
+        assertThat(result).allSatisfy(r -> assertThat(r.getUserCount()).isEqualTo(1L));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `TrendingKeywordProjection` 인터페이스 생성 (`name`, `userCount` 필드)
- `KeywordRepository`에 `findTrendingKeywords(Pageable)` JPQL 집계 쿼리 추가
- `KeywordRepositoryTest`에 트렌딩 키워드 조회 테스트 5건 추가

## 구현 상세
- `SELECT k.name, COUNT(DISTINCT k.user.id)` 쿼리로 사용자 등록 수 기준 인기 키워드 집계
- `RecommendedSourceProjection` 패턴을 따라 인터페이스 기반 Projection 사용
- `Pageable`을 통한 상위 N개 키워드 페이징 지원

## Test plan
- [x] 사용자 등록 수 기준 인기 키워드 정렬 확인
- [x] Pageable로 상위 N개 제한 확인
- [x] 키워드 없을 때 빈 목록 반환 확인
- [x] DISTINCT 사용자 카운트 정확성 확인
- [x] 여러 사용자 동일 키워드 등록 시 카운트 확인
- [x] 전체 빌드 성공 확인

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)