### PR TITLE
[REFACTOR] DTO 빌더를 생성자로 간소화 및 BDDMockito 스타일 통일

### DIFF
--- a/identity-service/src/main/java/com/leedahun/identityservice/domain/keyword/service/impl/KeywordServiceImpl.java
+++ b/identity-service/src/main/java/com/leedahun/identityservice/domain/keyword/service/impl/KeywordServiceImpl.java
@@ -97,10 +97,7 @@ public class KeywordServiceImpl implements KeywordService {
         int limitedSize = Math.min(Math.max(size, 1), TRENDING_MAX_SIZE);
         return keywordRepository.findTrendingKeywords(PageRequest.of(0, limitedSize))
                 .stream()
-                .map(projection -> TrendingKeywordResponseDto.builder()
-                        .name(projection.getName())
-                        .userCount(projection.getUserCount())
-                        .build())
+                .map(projection -> new TrendingKeywordResponseDto(projection.getName(), projection.getUserCount()))
                 .toList();
     }
 

--- a/identity-service/src/test/java/com/leedahun/identityservice/domain/keyword/controller/KeywordControllerTest.java
+++ b/identity-service/src/test/java/com/leedahun/identityservice/domain/keyword/controller/KeywordControllerTest.java
@@ -171,17 +171,11 @@ class KeywordControllerTest {
     void getTrendingKeywords_success() throws Exception {
         // given
         List<TrendingKeywordResponseDto> trendingList = List.of(
-                TrendingKeywordResponseDto.builder()
-                        .name("AI")
-                        .userCount(42L)
-                        .build(),
-                TrendingKeywordResponseDto.builder()
-                        .name("Spring")
-                        .userCount(35L)
-                        .build()
+                new TrendingKeywordResponseDto("AI", 42L),
+                new TrendingKeywordResponseDto("Spring", 35L)
         );
 
-        when(keywordService.getTrendingKeywords(anyInt())).thenReturn(trendingList);
+        given(keywordService.getTrendingKeywords(anyInt())).willReturn(trendingList);
 
         // when & then
         mockMvc.perform(get("/api/keywords/trending"))
@@ -195,14 +189,14 @@ class KeywordControllerTest {
                 .andExpect(jsonPath("$.data[1].userCount").value(35));
 
         // verify
-        verify(keywordService, times(1)).getTrendingKeywords(anyInt());
+        then(keywordService).should(times(1)).getTrendingKeywords(anyInt());
     }
 
     @Test
     @DisplayName("[GET /api/keywords/trending] 키워드가 없을 때 빈 배열을 반환한다")
     void getTrendingKeywords_empty() throws Exception {
         // given
-        when(keywordService.getTrendingKeywords(anyInt())).thenReturn(List.of());
+        given(keywordService.getTrendingKeywords(anyInt())).willReturn(List.of());
 
         // when & then
         mockMvc.perform(get("/api/keywords/trending"))
@@ -212,14 +206,14 @@ class KeywordControllerTest {
                 .andExpect(jsonPath("$.data", hasSize(0)));
 
         // verify
-        verify(keywordService, times(1)).getTrendingKeywords(anyInt());
+        then(keywordService).should(times(1)).getTrendingKeywords(anyInt());
     }
 
     @Test
     @DisplayName("[GET /api/keywords/trending] size 파라미터로 조회 개수를 지정할 수 있다")
     void getTrendingKeywords_withSizeParam() throws Exception {
         // given
-        when(keywordService.getTrendingKeywords(anyInt())).thenReturn(List.of());
+        given(keywordService.getTrendingKeywords(anyInt())).willReturn(List.of());
 
         // when & then
         mockMvc.perform(get("/api/keywords/trending")
@@ -228,6 +222,6 @@ class KeywordControllerTest {
                 .andExpect(jsonPath("$.status").value(200));
 
         // verify
-        verify(keywordService, times(1)).getTrendingKeywords(5);
+        then(keywordService).should(times(1)).getTrendingKeywords(5);
     }
 }


### PR DESCRIPTION
## Summary
- `KeywordServiceImpl`에서 `TrendingKeywordResponseDto` 생성 시 빌더 패턴 대신 생성자 직접 호출로 간소화
- `KeywordControllerTest`에서 `when/verify` → `given/then` BDDMockito 스타일로 통일
- 테스트 데이터 생성도 빌더 → 생성자로 간소화

## Test plan
- [x] `KeywordServiceTest` 전체 통과 확인
- [x] `KeywordControllerTest` 전체 통과 확인
- [x] `./gradlew :identity-service:test` BUILD SUCCESSFUL