### PR TITLE
[refactor] originalUrl 기반 결정론적 ID 생성으로 멱등성 보장

### DIFF
--- a/match-service/src/main/java/com/leedahun/matchservice/domain/content/service/impl/ContentServiceImpl.java
+++ b/match-service/src/main/java/com/leedahun/matchservice/domain/content/service/impl/ContentServiceImpl.java
@@ -4,7 +4,9 @@ import com.leedahun.matchservice.domain.content.document.ContentDocument;
 import com.leedahun.matchservice.domain.content.repository.ContentDocumentRepository;
 import com.leedahun.matchservice.domain.content.service.ContentService;
 import com.leedahun.matchservice.infra.kafka.dto.CrawledContentDto;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -20,7 +22,10 @@ public class ContentServiceImpl implements ContentService {
     @Transactional
     public void saveContent(CrawledContentDto dto) {
 
+        String id = UUID.nameUUIDFromBytes(dto.getOriginalUrl().getBytes(StandardCharsets.UTF_8)).toString();
+
         ContentDocument contentDocument = ContentDocument.builder()
+                .id(id)
                 .sourceId(dto.getSourceId())
                 .title(dto.getTitle())
                 .summary(dto.getSummary())


### PR DESCRIPTION
## Summary

- Kafka Consumer 재시도 시 ES에 동일 콘텐츠가 중복 저장되는 Dual Write 문제 해결
- `originalUrl`을 `UUID.nameUUIDFromBytes()`에 적용하여 결정론적 ID 생성 후 `ContentDocument` 빌더에 주입
- 동일 URL은 항상 동일 ID를 생성하므로 `save()` 호출이 ES Upsert로 동작하여 중복 방지

## 변경 사항

**`ContentServiceImpl.java`**
- `UUID.nameUUIDFromBytes(originalUrl.getBytes(StandardCharsets.UTF_8))`로 ID 생성
- 생성된 ID를 `ContentDocument` 빌더의 `.id(...)` 에 주입

## Test plan

- [x] 기존 `ContentServiceTest` 통과 확인
- [x] `./gradlew build` 빌드 성공 확인

Closes #177