### PR TITLE
[TEST] ContentServiceTest 멱등성 검증 테스트 추가

### DIFF
--- a/match-service/src/test/java/com/leedahun/matchservice/domain/content/service/ContentServiceTest.java
+++ b/match-service/src/test/java/com/leedahun/matchservice/domain/content/service/ContentServiceTest.java
@@ -1,6 +1,6 @@
 package com.leedahun.matchservice.domain.content.service;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -9,9 +9,11 @@ import com.leedahun.matchservice.domain.content.repository.ContentDocumentReposi
 import com.leedahun.matchservice.domain.content.service.impl.ContentServiceImpl;
 import com.leedahun.matchservice.infra.kafka.dto.CrawledContentDto;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -26,7 +28,7 @@ class ContentServiceTest {
     private ContentDocumentRepository contentDocumentRepository;
 
     @Test
-    @DisplayName("중복되지 않은 새로운 콘텐츠는 DB에 저장되어야 한다")
+    @DisplayName("콘텐츠 저장 시 ES 문서에 null이 아닌 ID가 설정되어야 한다")
     void saveContent_Success_NewContent() {
         // given
         CrawledContentDto dto = CrawledContentDto.builder()
@@ -38,12 +40,73 @@ class ContentServiceTest {
                 .publishedAt(LocalDateTime.now())
                 .build();
 
+        ArgumentCaptor<ContentDocument> captor = ArgumentCaptor.forClass(ContentDocument.class);
+
         // when
         contentService.saveContent(dto);
 
         // then
-        // save 메서드가 1번 호출되었는지 확인 (저장 성공)
-        verify(contentDocumentRepository, times(1)).save(any(ContentDocument.class));
+        verify(contentDocumentRepository, times(1)).save(captor.capture());
+        ContentDocument saved = captor.getValue();
+        assertThat(saved.getId()).isNotNull();
     }
 
+    @Test
+    @DisplayName("동일한 originalUrl로 두 번 저장해도 동일한 ID의 문서가 생성되어야 한다 (멱등성)")
+    void saveContent_Idempotent_SameUrlProducesSameId() {
+        // given
+        CrawledContentDto dto = CrawledContentDto.builder()
+                .sourceId(1L)
+                .title("Same Article")
+                .summary("Summary")
+                .originalUrl("https://blog.com/post/1")
+                .thumbnailUrl("https://img.com/1.jpg")
+                .publishedAt(LocalDateTime.now())
+                .build();
+
+        ArgumentCaptor<ContentDocument> captor = ArgumentCaptor.forClass(ContentDocument.class);
+
+        // when
+        contentService.saveContent(dto);
+        contentService.saveContent(dto);
+
+        // then
+        verify(contentDocumentRepository, times(2)).save(captor.capture());
+        List<ContentDocument> savedDocs = captor.getAllValues();
+        assertThat(savedDocs.get(0).getId()).isEqualTo(savedDocs.get(1).getId());
+    }
+
+    @Test
+    @DisplayName("서로 다른 originalUrl은 서로 다른 ID를 생성해야 한다")
+    void saveContent_DifferentUrls_ProduceDifferentIds() {
+        // given
+        CrawledContentDto dto1 = CrawledContentDto.builder()
+                .sourceId(1L)
+                .title("Article 1")
+                .summary("Summary 1")
+                .originalUrl("https://blog.com/post/1")
+                .thumbnailUrl("https://img.com/1.jpg")
+                .publishedAt(LocalDateTime.now())
+                .build();
+
+        CrawledContentDto dto2 = CrawledContentDto.builder()
+                .sourceId(1L)
+                .title("Article 2")
+                .summary("Summary 2")
+                .originalUrl("https://blog.com/post/2")
+                .thumbnailUrl("https://img.com/2.jpg")
+                .publishedAt(LocalDateTime.now())
+                .build();
+
+        ArgumentCaptor<ContentDocument> captor = ArgumentCaptor.forClass(ContentDocument.class);
+
+        // when
+        contentService.saveContent(dto1);
+        contentService.saveContent(dto2);
+
+        // then
+        verify(contentDocumentRepository, times(2)).save(captor.capture());
+        List<ContentDocument> savedDocs = captor.getAllValues();
+        assertThat(savedDocs.get(0).getId()).isNotEqualTo(savedDocs.get(1).getId());
+    }
 }


### PR DESCRIPTION
## Summary

- `ContentServiceImpl.saveContent()` 의 멱등성(Idempotency)을 검증하는 테스트 3건 추가
- 기존 테스트를 `ArgumentCaptor` 기반으로 강화하여 저장된 문서의 ID 비null 검증 포함

## 변경 사항

**`ContentServiceTest.java`**

| 테스트명 | 검증 내용 |
|---|---|
| `saveContent_Success_NewContent` | `save()` 호출 후 저장된 문서의 `id`가 `null`이 아닌지 검증 |
| `saveContent_Idempotent_SameUrlProducesSameId` | 동일 URL로 2회 호출 시 두 문서의 ID가 동일한지 검증 |
| `saveContent_DifferentUrls_ProduceDifferentIds` | 서로 다른 URL은 서로 다른 ID를 생성하는지 검증 |

## Test plan

- [x] 3개 신규 테스트 모두 통과
- [x] 기존 테스트 전체 통과
- [x] `./gradlew test` BUILD SUCCESSFUL 확인

> **Note:** `issue-177` (#179) 머지 후 이 PR의 변경이 유효합니다.

Closes #178